### PR TITLE
Use stable version of test containers

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -31,7 +31,7 @@ object Versions {
     val jacksonYaml = "2.9.6"
     val jacksonJSR310 = "2.9.6"
 
-    val testContainers = "1.9.0-rc1"
+    val testContainers = "1.9.1"
     val jupiterEngine = "5.1.0"
 }
 


### PR DESCRIPTION
Migrate from 1.9.0-rc1 to 1.9.1