### PR TITLE
Fixing multiple issues related to test runs

### DIFF
--- a/.buildsystem/deploy.sh
+++ b/.buildsystem/deploy.sh
@@ -13,7 +13,7 @@ then
     exit 1
 fi
 
-if [ -z "GPG_PASSPHRASE" ]
+if [ -z "$GPG_PASSPHRASE" ]
 then
     echo "error: please set GPG_PASSPHRASE environment variable"
     exit 1

--- a/buildSrc/src/main/kotlin/Deployment.kt
+++ b/buildSrc/src/main/kotlin/Deployment.kt
@@ -20,8 +20,10 @@ object Deployment {
     var versionSuffix: String? = null
     var deployUrl: String? = null
 
-    val snapshotDeployUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-    val releaseDeployUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    val snapshotDeployUrl = System.getenv("SONATYPE_SNAPSHOTS_URL")
+            ?: "https://oss.sonatype.org/content/repositories/snapshots/"
+    val releaseDeployUrl = System.getenv("SONATYPE_RELEASES_URL")
+            ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
     fun initialize(project: Project) {
         val releaseMode: String? by project

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    val marathon = "0.2.2"
+    val marathon = System.getenv("DEPLOY_VERSION_OVERRIDE") ?: "0.2.2"
 
     val kotlin = "1.2.61"
     val coroutines = "0.25.0"

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -60,12 +60,16 @@ buildConfig {
     version = Versions.marathon
 }
 
+sourceSets["main"].java {
+    srcDirs.add(File(buildDir, "gen"))
+}
+
 // At the moment for non-Android projects you need to explicitly
 // mark the generated code for correct highlighting in IDE.
 idea {
     module {
-        sourceDirs = sourceDirs + file("build/gen/buildconfig/src/main")
-        generatedSourceDirs = generatedSourceDirs + file("build/gen/buildconfig/src/main")
+        sourceDirs = sourceDirs + file("${project.buildDir}/gen/buildconfig/src/main")
+        generatedSourceDirs = generatedSourceDirs + file("${project.buildDir}/gen/buildconfig/src/main")
     }
 }
 

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/DeserializeModule.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/DeserializeModule.kt
@@ -6,6 +6,7 @@ import com.malinskiy.marathon.cli.config.deserialize.AnalyticsConfigurationDeser
 import com.malinskiy.marathon.cli.config.deserialize.BatchingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.ExecutionTimeSortingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.FileVendorConfigurationDeserializer
+import com.malinskiy.marathon.cli.config.deserialize.FixedSizeBatchingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.FlakinessStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.InfluxDbConfigurationDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.PoolingStrategyDeserializer
@@ -23,6 +24,7 @@ import com.malinskiy.marathon.execution.strategy.PoolingStrategy
 import com.malinskiy.marathon.execution.strategy.RetryStrategy
 import com.malinskiy.marathon.execution.strategy.ShardingStrategy
 import com.malinskiy.marathon.execution.strategy.SortingStrategy
+import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.flakiness.ProbabilityBasedFlakinessStrategy
 import com.malinskiy.marathon.execution.strategy.impl.sorting.ExecutionTimeSortingStrategy
 
@@ -39,6 +41,8 @@ class DeserializeModule(instantTimeProvider: InstantTimeProvider): SimpleModule(
         addDeserializer(FlakinessStrategy::class.java, FlakinessStrategyDeserializer())
         addDeserializer(ProbabilityBasedFlakinessStrategy::class.java,
                 ProbabilityBasedFlakinessStrategyDeserializer(instantTimeProvider))
+        addDeserializer(FixedSizeBatchingStrategy::class.java,
+                FixedSizeBatchingStrategyDeserializer(instantTimeProvider))
         addDeserializer(RetryStrategy::class.java, RetryStrategyDeserializer())
         addDeserializer(TestFilter::class.java, TestFilterDeserializer())
         addDeserializer(FileVendorConfiguration::class.java, FileVendorConfigurationDeserializer())

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/FixedSizeBatchingStrategyDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/FixedSizeBatchingStrategyDeserializer.kt
@@ -1,0 +1,49 @@
+package com.malinskiy.marathon.cli.config.deserialize
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.TreeNode
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
+import com.malinskiy.marathon.exceptions.ConfigurationException
+import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
+import java.time.Duration
+import java.time.Instant
+
+class FixedSizeBatchingStrategyDeserializer(private val instantTimeProvider: InstantTimeProvider):
+        StdDeserializer<FixedSizeBatchingStrategy>(FixedSizeBatchingStrategy::class.java) {
+    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): FixedSizeBatchingStrategy {
+        val codec = p?.codec as ObjectMapper
+        val node: JsonNode = codec.readTree(p) ?: throw ConfigurationException("Invalid sorting strategy")
+
+        val size = node.findValue("percentile")?.asInt()
+                ?: throw ConfigurationException("Missing size value")
+
+        val durationMillis = node.findValue("durationMillis")?.asLong()
+                ?: throw ConfigurationException("Missing durationMillis value")
+
+        val percentile = node.findValue("percentile")?.asDouble()
+                ?: throw ConfigurationException("Missing percentile value")
+
+        val timeLimitValue = node.findValue("timeLimit")
+                ?: throw ConfigurationException("Missing time limit value")
+        val instant = codec.treeToValueOrNull(timeLimitValue, Instant::class.java)
+                ?: codec.treeToValueOrNull(timeLimitValue, Duration::class.java)?.
+                        addToInstant(instantTimeProvider.referenceTime())
+                ?: throw ConfigurationException("Can't deserialize timeLimit")
+
+        return FixedSizeBatchingStrategy(size, durationMillis, percentile, instant)
+    }
+}
+
+private fun Duration.addToInstant(instant: Instant): Instant = instant.plus(this)
+private fun <T> ObjectMapper.treeToValueOrNull(node: TreeNode, clazz: Class<T>): T? {
+    val result: T
+    try {
+        result = treeToValue(node, clazz)
+    } catch (e: InvalidFormatException) { return null }
+    return result
+}

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/FixedSizeBatchingStrategyDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/FixedSizeBatchingStrategyDeserializer.kt
@@ -24,6 +24,7 @@ class FixedSizeBatchingStrategyDeserializer(private val instantTimeProvider: Ins
 
         val durationMillis = node.findValue("durationMillis")?.asLong()
         val percentile = node.findValue("percentile")?.asDouble()
+        val lastMileLength = node.findValue("lastMileLength")?.asInt()
 
         val timeLimitValue: JsonNode? = node.findValue("timeLimit")
         val instant = timeLimitValue?.let {
@@ -31,7 +32,7 @@ class FixedSizeBatchingStrategyDeserializer(private val instantTimeProvider: Ins
                     ?: codec.treeToValueOrNull(timeLimitValue, Duration::class.java)?.addToInstant(instantTimeProvider.referenceTime())
         }
 
-        return FixedSizeBatchingStrategy(size, durationMillis, percentile, instant)
+        return FixedSizeBatchingStrategy(size, durationMillis, percentile, instant, lastMileLength ?: 0)
     }
 }
 

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxDbProviderIntegrationSpec.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxDbProviderIntegrationSpec.kt
@@ -1,0 +1,57 @@
+package com.malinskiy.marathon.analytics.metrics.remote.influx
+
+import com.malinskiy.marathon.TestGenerator
+import com.malinskiy.marathon.analytics.tracker.remote.influx.InfluxDbProvider
+import com.malinskiy.marathon.execution.AnalyticsConfiguration
+import org.amshove.kluent.shouldEqualTo
+import org.influxdb.InfluxDB
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class InfluxDbProviderIntegrationSpec : Spek({
+    val database = "marathonTest"
+
+    val container = KInfluxDBContainer().withAuthEnabled(false)
+
+    var thirdDbInstance: InfluxDB? = null
+
+    beforeGroup {
+        container.start()
+    }
+    afterGroup {
+        thirdDbInstance?.close()
+        container.stop()
+    }
+
+    describe("InfluxDbProvider") {
+        group("multiple creations") {
+            val test = TestGenerator().create(1).first()
+            it("should still have the same configured retention policy") {
+                val provider = InfluxDbProvider(AnalyticsConfiguration.InfluxDbConfiguration(
+                        url = container.url,
+                        dbName = database,
+                        password = "",
+                        user = "root",
+                        retentionPolicyConfiguration = AnalyticsConfiguration.InfluxDbConfiguration.RetentionPolicyConfiguration.default
+                ))
+                val firstDbInstance = provider.createDb()
+                firstDbInstance.close()
+
+
+                val secondDbInstance = provider.createDb()
+                prepareData(secondDbInstance, test)
+                secondDbInstance.close()
+
+                thirdDbInstance = provider.createDb()
+
+                val metricsProvider = InfluxMetricsProvider(thirdDbInstance!!, database)
+
+                val result = metricsProvider.executionTime(test, 50.0, Instant.now().minus(2, ChronoUnit.DAYS))
+                result shouldEqualTo 5000.0
+            }
+        }
+    }
+})

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProviderIntegrationSpec.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProviderIntegrationSpec.kt
@@ -47,9 +47,9 @@ class InfluxMetricsProviderIntegrationSpec : Spek({
                 val result = provider.invoke().successRate(test, Instant.now())
                 result shouldEqualTo 0.0
             }
-            it("execution time default value is 0.0") {
+            it("execution time default value is 300_000.0") {
                 val result = provider.invoke().executionTime(test, 90.0, Instant.now())
-                result shouldEqualTo 0.0
+                result shouldEqualTo 300_000.0
             }
         }
         group("execution time") {

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -44,7 +44,7 @@ class Marathon(val configuration: Configuration) {
         if (configuration.debug) {
             return CompositeSummaryPrinter(listOf(
                     htmlSummaryPrinter,
-                    TimelineSummaryPrinter(TimelineSummarySerializer(testResultReporter), gson, outputDir)
+                    TimelineSummaryPrinter(TimelineSummarySerializer(analyticsFactory.rawTestResultTracker), gson, outputDir)
             ))
         }
         return htmlSummaryPrinter

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -99,8 +99,8 @@ class Marathon(val configuration: Configuration) {
         }
 
         val hours = TimeUnit.MILLISECONDS.toHours(timeMillis)
-        val minutes = TimeUnit.MILLISECONDS.toMinutes(timeMillis)
-        val seconds = TimeUnit.MILLISECONDS.toSeconds(timeMillis)
+        val minutes = TimeUnit.MILLISECONDS.toMinutes(timeMillis) % 60
+        val seconds = TimeUnit.MILLISECONDS.toSeconds(timeMillis) % 60
 
         log.info { "Total time: ${hours}H ${minutes}m ${seconds}s" }
         analytics.terminate()

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/Analytics.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/Analytics.kt
@@ -3,4 +3,4 @@ package com.malinskiy.marathon.analytics
 import com.malinskiy.marathon.analytics.metrics.MetricsProvider
 import com.malinskiy.marathon.analytics.tracker.Tracker
 
-class Analytics(tracker: Tracker, metricsProvider: MetricsProvider) : Tracker by tracker, MetricsProvider by metricsProvider
+class Analytics(tracker: Tracker, val metricsProvider: MetricsProvider) : Tracker by tracker, MetricsProvider by metricsProvider

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/AnalyticsFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/AnalyticsFactory.kt
@@ -19,4 +19,6 @@ class AnalyticsFactory(configuration: Configuration,
             gson)
 
     fun create(): Analytics = Analytics(trackerFactory.create(), metricsFactory.create())
+
+    val rawTestResultTracker = trackerFactory.rawTestResultTracker
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProvider.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProvider.kt
@@ -44,7 +44,7 @@ class InfluxMetricsProvider(private val influxDb: InfluxDB,
 
         val successRate = successRate[test.toSafeTestName()]
         return if(successRate == null) {
-            logger.warn { "No success rate found for ${test.toSafeTestName()}. Using 0" }
+            logger.warn { "No success rate found for ${test.toSafeTestName()}. Using 0 i.e. fails all the time" }
             0.0
         } else {
             successRate
@@ -75,8 +75,8 @@ class InfluxMetricsProvider(private val influxDb: InfluxDB,
 
         val executionTime = executionTime[test.toSafeTestName()]
         return if(executionTime == null) {
-            logger.warn { "No execution time found for ${test.toSafeTestName()}. Using 0" }
-            0.0
+            logger.warn { "No execution time found for ${test.toSafeTestName()}. Using 300_000 seconds i.e. long test" }
+            300_000.0
         } else {
             executionTime
         }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProvider.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/metrics/remote/influx/InfluxMetricsProvider.kt
@@ -1,6 +1,7 @@
 package com.malinskiy.marathon.analytics.metrics.remote.influx
 
 import com.malinskiy.marathon.analytics.metrics.MetricsProvider
+import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.toSafeTestName
 import org.influxdb.InfluxDB
@@ -20,6 +21,8 @@ class SuccessRate(@Column(name = "testname", tag = true) var testName: String? =
 
 class InfluxMetricsProvider(private val influxDb: InfluxDB,
                             private val dbName: String) : MetricsProvider {
+
+    private val logger = MarathonLogging.logger(InfluxMetricsProvider::class.java.simpleName)
     private val mapper = InfluxDBResultMapper()
 
     private val successRate = mutableMapOf<String, Double>()
@@ -38,7 +41,14 @@ class InfluxMetricsProvider(private val influxDb: InfluxDB,
             }
             successRateInitialized = true
         }
-        return successRate[test.toSafeTestName()] ?: 0.0
+
+        val successRate = successRate[test.toSafeTestName()]
+        return if(successRate == null) {
+            logger.warn { "No success rate found for ${test.toSafeTestName()}. Using 0" }
+            0.0
+        } else {
+            successRate
+        }
     }
 
     private fun requestAllSuccessRates(limit: Instant): List<SuccessRate> {
@@ -62,7 +72,14 @@ class InfluxMetricsProvider(private val influxDb: InfluxDB,
             }
             executionTimeInitialized = true
         }
-        return executionTime[test.toSafeTestName()] ?: 0.0
+
+        val executionTime = executionTime[test.toSafeTestName()]
+        return if(executionTime == null) {
+            logger.warn { "No execution time found for ${test.toSafeTestName()}. Using 0" }
+            0.0
+        } else {
+            executionTime
+        }
     }
 
     private fun requestAllExecutionTimes(percentile: Double,

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/NoOpTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/NoOpTracker.kt
@@ -9,7 +9,7 @@ import com.malinskiy.marathon.execution.queue.TestAction
 import com.malinskiy.marathon.execution.queue.TestEvent
 import com.malinskiy.marathon.execution.queue.TestState
 
-internal open class NoOpTracker : Tracker {
+open class NoOpTracker : Tracker {
 
     override fun terminate() {}
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/TrackerFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/TrackerFactory.kt
@@ -19,12 +19,15 @@ internal class TrackerFactory(private val configuration: Configuration,
                               private val deviceInfoReporter: DeviceInfoReporter,
                               private val testResultReporter: TestResultReporter,
                               private val gson: Gson) {
+
+    val rawTestResultTracker = RawTestResultTracker(fileManager, gson)
+
     fun create(): Tracker {
         val defaultTrackers = listOf(
                 JUnitTracker(JUnitReporter(fileManager)),
                 DeviceTracker(deviceInfoReporter),
                 TestRusultsTracker(testResultReporter),
-                RawTestResultTracker(fileManager, gson)
+                rawTestResultTracker
         )
         return when {
             configuration.analyticsConfiguration is InfluxDbConfiguration -> {

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/local/RawTestResultTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/local/RawTestResultTracker.kt
@@ -8,7 +8,7 @@ import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.execution.TestResult
 import com.malinskiy.marathon.io.FileManager
 
-internal class RawTestResultTracker(private val fileManager: FileManager,
+class RawTestResultTracker(private val fileManager: FileManager,
                                     private val gson: Gson) : NoOpTracker() {
 
     var testResults: MutableList<RawTestRun> = mutableListOf()
@@ -27,15 +27,17 @@ internal class RawTestResultTracker(private val fileManager: FileManager,
                 device.serialNumber,
                 testResult.isIgnored,
                 testResult.isSuccess,
-                testResult.startTime
+                testResult.startTime,
+                testResult.durationMillis()
         ))
     }
 
-    data class RawTestRun(@SerializedName("package") private val pkg: String,
-                          @SerializedName("class") private val clazz: String,
-                          @SerializedName("method") private val method: String,
-                          @SerializedName("deviceSerial") private val deviceSerial: String,
-                          @SerializedName("ignored") private val ignored: Boolean,
-                          @SerializedName("success") private val success: Boolean,
-                          @SerializedName("timestamp") private val timestamp: Long)
+    data class RawTestRun(@SerializedName("package") val pkg: String,
+                          @SerializedName("class") val clazz: String,
+                          @SerializedName("method") val method: String,
+                          @SerializedName("deviceSerial") val deviceSerial: String,
+                          @SerializedName("ignored") val ignored: Boolean,
+                          @SerializedName("success") val success: Boolean,
+                          @SerializedName("timestamp") val timestamp: Long,
+                          @SerializedName("duration") val duration: Long)
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/remote/influx/InfluxDbProvider.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/remote/influx/InfluxDbProvider.kt
@@ -4,7 +4,7 @@ import com.malinskiy.marathon.execution.AnalyticsConfiguration
 import org.influxdb.InfluxDB
 import org.influxdb.InfluxDBFactory
 
-internal class InfluxDbProvider(configuration: AnalyticsConfiguration.InfluxDbConfiguration) {
+class InfluxDbProvider(configuration: AnalyticsConfiguration.InfluxDbConfiguration) {
 
     private val url = configuration.url
     private val user = configuration.user
@@ -19,18 +19,21 @@ internal class InfluxDbProvider(configuration: AnalyticsConfiguration.InfluxDbCo
             InfluxDBFactory.connect(url)
         }
         influxDb.setLogLevel(InfluxDB.LogLevel.BASIC)
+
+        val rpName = retentionPolicyConfiguration.name
         if (!influxDb.databaseExists(dbName)) {
             influxDb.createDatabase(dbName)
-            val rpName = retentionPolicyConfiguration.name
+
             val duration = retentionPolicyConfiguration.duration
             val shardDuration = retentionPolicyConfiguration.shardDuration
             val replicationFactor = retentionPolicyConfiguration.replicationFactor
             val isDefault = retentionPolicyConfiguration.isDefault
 
             influxDb.createRetentionPolicy(rpName, dbName, duration, shardDuration, replicationFactor, isDefault)
-            influxDb.setRetentionPolicy(rpName)
         }
+
         influxDb.setDatabase(dbName)
+        influxDb.setRetentionPolicy(rpName)
         influxDb.enableBatch()
         return influxDb
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/exceptions/TestBatchExecutionException.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/exceptions/TestBatchExecutionException.kt
@@ -1,0 +1,6 @@
+package com.malinskiy.marathon.exceptions
+
+class TestBatchExecutionException: RuntimeException {
+    constructor(cause: Throwable): super(cause)
+    constructor(message: String): super(message)
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -105,6 +105,11 @@ class DevicePoolActor(private val poolId: DevicePoolId,
     private fun noActiveDevices() = devices.isEmpty() || devices.all { it.value.isClosedForSend }
 
     private suspend fun addDevice(device: Device) {
+        if (devices.containsKey(device.serialNumber)) {
+            logger.warn { "device ${device.serialNumber} already present in pool ${poolId.name}" }
+            return
+        }
+
         logger.debug { "add device ${device.serialNumber}" }
         val actor = DeviceActor(poolId, this, configuration, device, progressReporter, poolJob)
         devices[device.serialNumber] = actor

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -97,6 +97,7 @@ class DevicePoolActor(private val poolId: DevicePoolId,
         actor?.send(DeviceEvent.Terminate)
         logger.debug { "devices.size = ${devices.size}" }
         if (noActiveDevices()) {
+            //TODO check if we still have tests and timeout if nothing available
             terminate()
         }
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Scheduler.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Scheduler.kt
@@ -83,9 +83,11 @@ class Scheduler(private val deviceProvider: DeviceProvider,
         val poolId = poolingStrategy.associate(device)
         logger.debug { "device ${device.serialNumber} associated with poolId ${poolId.name}" }
         pools.computeIfAbsent(poolId) { id ->
+            logger.debug { "pool actor ${id.name} is being created" }
             DevicePoolActor(id, configuration, analytics, tests, progressReporter, parent)
         }
-        pools[poolId]?.send(AddDevice(device))
+        pools[poolId]?.send(AddDevice(device)) ?: logger.debug { "not sending the AddDevice event " +
+                "to device pool for ${device.serialNumber}" }
         analytics.trackDeviceConnected(poolId, device)
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
@@ -1,7 +1,9 @@
 package com.malinskiy.marathon.execution
 
 import com.malinskiy.marathon.device.Device
+import com.malinskiy.marathon.test.Test
 
 data class TestBatchResults(val device: Device,
                             val finished: Collection<TestResult>,
-                            val failed: Collection<TestResult>)
+                            val failed: Collection<TestResult>,
+                            val uncompleted: Collection<Test>)

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
@@ -22,4 +22,6 @@ data class TestResult(val test: Test,
             TestStatus.PASSED -> true
             else -> false
         }
+
+    val isTimeInfoAvailable = startTime != 0L && endTime != 0L
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -152,7 +152,7 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
     private fun initialize() {
         logger.debug { "initialize ${device.serialNumber}" }
         job = async(context, parent = deviceJob) {
-            withRetry(10, 1000) {
+            withRetry(30, 10000) {
                 try {
                     device.prepare(configuration)
                 } catch (e: Exception) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -4,6 +4,7 @@ import com.malinskiy.marathon.actor.Actor
 import com.malinskiy.marathon.actor.StateMachine
 import com.malinskiy.marathon.device.Device
 import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.exceptions.TestBatchExecutionException
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.DevicePoolMessage
 import com.malinskiy.marathon.execution.DevicePoolMessage.FromDevice.RequestNextBatch
@@ -157,7 +158,11 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
     private fun executeBatch(batch: TestBatch, result: CompletableDeferred<TestBatchResults>) {
         logger.debug { "executeBatch" }
         job = async(context, parent = deviceJob) {
-            device.execute(configuration, devicePoolId, batch, result, progressReporter)
+            try {
+                device.execute(configuration, devicePoolId, batch, result, progressReporter)
+            } catch (e: TestBatchExecutionException) {
+                returnBatch(batch)
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -156,6 +156,7 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
         logger.debug { "initialize ${device.serialNumber}" }
         job = async(context, parent = deviceJob) {
             withRetry(30, 10000) {
+                if(!isActive) return@async
                 try {
                     device.prepare(configuration)
                 } catch (e: Exception) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -101,10 +101,10 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
                 }
                 is DeviceAction.Terminate -> {
                     val batch = sideEffect.batch
+                    terminate()
                     batch?.let {
                         returnBatch(it)
                     }
-                    terminate()
                 }
             }
         }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -151,7 +151,11 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
     private fun initialize() {
         logger.debug { "initialize" }
         job = async(context, parent = deviceJob) {
-            device.prepare(configuration)
+            try {
+                device.prepare(configuration)
+            } catch (e: Exception) {
+                terminate()
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -21,7 +21,7 @@ import java.util.*
 
 class QueueActor(configuration: Configuration,
                  private val testShard: TestShard,
-                 analytics: Analytics,
+                 private val analytics: Analytics,
                  private val pool: SendChannel<FromQueue>,
                  private val poolId: DevicePoolId,
                  private val progressReporter: ProgressReporter,
@@ -148,7 +148,7 @@ class QueueActor(configuration: Configuration,
     }
 
     private suspend fun sendBatch(device: Device) {
-        val batch = batching.process(queue)
+        val batch = batching.process(queue, analytics)
         activeBatches[device] = batch
         pool.send(FromQueue.ExecuteBatch(device, batch))
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -67,12 +67,16 @@ class QueueActor(configuration: Configuration,
     private suspend fun onBatchCompleted(device: Device, results: TestBatchResults) {
         val finished = results.finished
         val failed = results.failed
+        val uncompleted = results.uncompleted
         logger.debug { "handle test results ${device.serialNumber}" }
         if (finished.isNotEmpty()) {
             handleFinishedTests(finished, device)
         }
         if (failed.isNotEmpty()) {
             handleFailedTests(failed, device)
+        }
+        if (uncompleted.isNotEmpty()) {
+            returnTests(uncompleted)
         }
         activeBatches.remove(device.serialNumber)
         onRequestBatch(device)
@@ -142,8 +146,10 @@ class QueueActor(configuration: Configuration,
             pool.send(DevicePoolMessage.FromQueue.Terminated)
             onTerminate()
         } else {
-            logger.debug { "queue is empty but there are active batches present for " +
-                    "${activeBatches.keys.joinToString { it }}" }
+            logger.debug {
+                "queue is empty but there are active batches present for " +
+                        "${activeBatches.keys.joinToString { it }}"
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -79,6 +79,7 @@ class QueueActor(configuration: Configuration,
     }
 
     private fun onReturnBatch(device: Device, batch: TestBatch) {
+        logger.debug { "onReturnBatch ${device.serialNumber}" }
         returnTests(batch.tests)
         activeBatches.remove(device)
     }
@@ -133,12 +134,16 @@ class QueueActor(configuration: Configuration,
         logger.debug { "request next batch for device ${device.serialNumber}" }
         val queueIsEmpty = queue.isEmpty()
         if (queue.isNotEmpty() && !activeBatches.containsKey(device)) {
+            logger.debug { "sending next batch for device ${device.serialNumber}" }
             sendBatch(device)
             return
         }
         if (queueIsEmpty && activeBatches.isEmpty()) {
             pool.send(DevicePoolMessage.FromQueue.Terminated)
             onTerminate()
+        } else {
+            logger.debug { "queue is empty but there are active batches present for " +
+                    "${activeBatches.keys.joinToString { it.serialNumber }}" }
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/BatchingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/BatchingStrategy.kt
@@ -1,9 +1,10 @@
 package com.malinskiy.marathon.execution.strategy
 
+import com.malinskiy.marathon.analytics.Analytics
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import java.util.*
 
 interface BatchingStrategy {
-    fun process(queue: Queue<Test>): TestBatch
+    fun process(queue: Queue<Test>, analytics: Analytics): TestBatch
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategy.kt
@@ -1,6 +1,5 @@
 package com.malinskiy.marathon.execution.strategy.impl.batching
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.analytics.Analytics
 import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.test.Test
@@ -10,8 +9,8 @@ import java.util.*
 
 class FixedSizeBatchingStrategy(private val size: Int,
                                 private val durationMillis: Long? = null,
-                                @JsonProperty("percentile") val percentile: Double? = null,
-                                @JsonProperty("timeLimit") val timeLimit: Instant? = null) : BatchingStrategy {
+                                private val percentile: Double? = null,
+                                private val timeLimit: Instant? = null) : BatchingStrategy {
 
     override fun process(queue: Queue<Test>, analytics: Analytics): TestBatch {
         var counter = 0

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategy.kt
@@ -8,8 +8,8 @@ import com.malinskiy.marathon.test.TestBatch
 import java.time.Instant
 import java.util.*
 
-class FixedSizeBatchingStrategy(@JsonProperty("size") private val size: Int,
-                                @JsonProperty("duration") private val duration: Int? = null,
+class FixedSizeBatchingStrategy(private val size: Int,
+                                private val durationMillis: Long? = null,
                                 @JsonProperty("percentile") val percentile: Double? = null,
                                 @JsonProperty("timeLimit") val timeLimit: Instant? = null) : BatchingStrategy {
 
@@ -27,13 +27,13 @@ class FixedSizeBatchingStrategy(@JsonProperty("size") private val size: Int,
                 result.add(item)
             }
 
-            if(duration != null && percentile != null && timeLimit != null) {
+            if(durationMillis != null && percentile != null && timeLimit != null) {
                 //Check for expected batch duration. If we hit the duration limit - break
                 //Important part is to add at least one test so that if one test is longer than a batch
                 //We still have at least one test
                 val expectedTestDuration = analytics.metricsProvider.executionTime(item, percentile, timeLimit)
                 expectedBatchDuration += expectedTestDuration
-                if(expectedBatchDuration >= duration) break
+                if(expectedBatchDuration >= durationMillis) break
             }
         }
         if (duplicates.isNotEmpty()) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/IsolateBatchingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/IsolateBatchingStrategy.kt
@@ -1,12 +1,13 @@
 package com.malinskiy.marathon.execution.strategy.impl.batching
 
+import com.malinskiy.marathon.analytics.Analytics
 import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import java.util.*
 
 class IsolateBatchingStrategy : BatchingStrategy {
-    override fun process(queue: Queue<Test>): TestBatch = TestBatch(listOf(queue.poll()))
+    override fun process(queue: Queue<Test>, analytics: Analytics): TestBatch = TestBatch(listOf(queue.poll()))
 
     override fun hashCode() = javaClass.canonicalName.hashCode()
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
@@ -16,7 +16,6 @@ class ExecutionTimeSortingStrategy(val percentile: Double,
     override fun process(metricsProvider: MetricsProvider): Comparator<Test> =
             Comparator.comparingDouble<Test> {
                 val expectedDuration = metricsProvider.executionTime(it, percentile, timeLimit)
-                logger.debug { "Expecting duration of $expectedDuration for ${it.toSimpleSafeTestName()}" }
                 expectedDuration
             }.reversed()
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
@@ -32,5 +32,3 @@ class ExecutionTimeSortingStrategy(val percentile: Double,
         return result
     }
 }
-
-private fun Long.toInstant(): Instant = Instant.now().plusMillis(this)

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategy.kt
@@ -2,16 +2,22 @@ package com.malinskiy.marathon.execution.strategy.impl.sorting
 
 import com.malinskiy.marathon.analytics.metrics.MetricsProvider
 import com.malinskiy.marathon.execution.strategy.SortingStrategy
+import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.toSimpleSafeTestName
 import java.time.Instant
-import java.util.Comparator
+import java.util.*
 
 class ExecutionTimeSortingStrategy(val percentile: Double,
                                    val timeLimit: Instant) : SortingStrategy {
 
+    val logger = MarathonLogging.logger(ExecutionTimeSortingStrategy::class.java.simpleName)
+
     override fun process(metricsProvider: MetricsProvider): Comparator<Test> =
             Comparator.comparingDouble<Test> {
-                metricsProvider.executionTime(it, percentile, timeLimit)
+                val expectedDuration = metricsProvider.executionTime(it, percentile, timeLimit)
+                logger.debug { "Expecting duration of $expectedDuration for ${it.toSimpleSafeTestName()}" }
+                expectedDuration
             }.reversed()
 
     override fun equals(other: Any?): Boolean {

--- a/core/src/main/kotlin/com/malinskiy/marathon/log/KLoggerDebug.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/log/KLoggerDebug.kt
@@ -1,0 +1,150 @@
+package com.malinskiy.marathon.log
+
+import mu.KLogger
+import org.slf4j.Marker
+
+class KLoggerDebug(underlyingLogger: KLogger): KLogger by underlyingLogger {
+    override fun debug(msg: () -> Any?) {
+        super.warn(msg)
+    }
+
+    override fun debug(t: Throwable, msg: () -> Any?) {
+        super.warn(t, msg)
+    }
+
+    override fun info(msg: () -> Any?) {
+        super.warn(msg)
+    }
+
+    override fun info(t: Throwable, msg: () -> Any?) {
+        super.warn(t, msg)
+    }
+
+    override fun trace(msg: () -> Any?) {
+        super.warn(msg)
+    }
+
+    override fun trace(t: Throwable, msg: () -> Any?) {
+        super.warn(t, msg)
+    }
+
+    override fun debug(format: String, vararg arguments: Any) {
+        warn(format, arguments)
+    }
+
+    override fun debug(marker: Marker?, format: String?, vararg arguments: Any?) {
+        warn(marker, format, arguments)
+    }
+
+    override fun debug(marker: Marker?, format: String?, arg: Any?) {
+        warn(marker, format, arg)
+    }
+
+    override fun debug(format: String?, arg: Any?) {
+        warn(format, arg)
+    }
+
+    override fun debug(marker: Marker?, msg: String?) {
+        warn(marker, msg)
+    }
+
+    override fun debug(format: String?, arg1: Any?, arg2: Any?) {
+        warn(format, arg1, arg2)
+    }
+
+    override fun debug(msg: String?, t: Throwable?) {
+        warn(msg, t)
+    }
+
+    override fun debug(marker: Marker?, msg: String?, t: Throwable?) {
+        warn(marker, msg, t)
+    }
+
+    override fun debug(msg: String?) {
+        warn(msg)
+    }
+
+    override fun debug(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
+        warn(marker, format, arg1, arg2)
+    }
+
+    override fun info(marker: Marker?, msg: String?) {
+        warn(marker, msg)
+    }
+
+    override fun info(format: String?, arg1: Any?, arg2: Any?) {
+        warn(format, arg1, arg2)
+    }
+
+    override fun info(marker: Marker?, format: String?, vararg arguments: Any?) {
+        warn(marker, format, arguments)
+    }
+
+    override fun info(marker: Marker?, msg: String?, t: Throwable?) {
+        warn(marker, msg, t)
+    }
+
+    override fun info(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
+        warn(marker, format, arg1, arg2)
+    }
+
+    override fun info(msg: String?) {
+        warn(msg)
+    }
+
+    override fun info(format: String?, vararg arguments: Any?) {
+        warn(format, arguments)
+    }
+
+    override fun info(msg: String?, t: Throwable?) {
+        warn(msg, t)
+    }
+
+    override fun info(marker: Marker?, format: String?, arg: Any?) {
+        warn(marker, format, arg)
+    }
+
+    override fun info(format: String?, arg: Any?) {
+        warn(format, arg)
+    }
+
+    override fun trace(format: String?, arg1: Any?, arg2: Any?) {
+        warn(format, arg1, arg2)
+    }
+
+    override fun trace(marker: Marker?, msg: String?, t: Throwable?) {
+        warn(marker, msg, t)
+    }
+
+    override fun trace(msg: String?) {
+        warn(msg)
+    }
+
+    override fun trace(format: String?, arg: Any?) {
+        warn(format, arg)
+    }
+
+    override fun trace(marker: Marker?, format: String?, arg: Any?) {
+        warn(marker, format, arg)
+    }
+
+    override fun trace(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) {
+        warn(marker, format, arg1, arg2)
+    }
+
+    override fun trace(marker: Marker?, format: String?, vararg argArray: Any?) {
+        warn(marker, format, argArray)
+    }
+
+    override fun trace(msg: String?, t: Throwable?) {
+        warn(msg, t)
+    }
+
+    override fun trace(marker: Marker?, msg: String?) {
+        warn(marker, msg)
+    }
+
+    override fun trace(format: String?, vararg arguments: Any?) {
+        warn(format, arguments)
+    }
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/log/MarathonLogging.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/log/MarathonLogging.kt
@@ -34,9 +34,11 @@ object MarathonLogging {
             if (debug && !warningPrinted) {
                 println("Can't change log level during runtime for " +
                         "${logger.underlyingLogger.javaClass.simpleName}. " +
-                        "Please configure your logger separately.")
+                        "Please configure your logger separately. " +
+                        "Wrapping the log and redirecting everything into warn for now")
                 warningPrinted = true
             }
+            return KLoggerDebug(logger)
         } else {
             internalLogger.level = level
                     ?: when {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
@@ -16,7 +16,10 @@ class TimelineSummarySerializer(private val testResultSerializer: TestResultRepo
 
     private fun parseData(poolId: DevicePoolId, device: DeviceInfo): List<Data> {
         val executions = testResultSerializer.readTests(poolId, device)
-        return executions.map { this.convertToData(it) }.sortedBy { it.startDate }
+        return executions
+                .filter { it.isTimeInfoAvailable } //Used for INCOMPLETE tests
+                .map { this.convertToData(it) }
+                .sortedBy { it.startDate }
     }
 
     private fun convertToData(testResult: TestResult): Data {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
@@ -9,13 +9,10 @@ import com.malinskiy.marathon.report.PoolSummary
 import com.malinskiy.marathon.report.Summary
 import com.malinskiy.marathon.report.internal.TestResultReporter
 import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.toSimpleSafeTestName
 
 class TimelineSummarySerializer(private val testResultSerializer: TestResultReporter) {
     val logger = MarathonLogging.logger(TimelineSummarySerializer::class.java.simpleName)
-
-    private fun prepareTestName(fullTestName: String): String {
-        return fullTestName.substring(fullTestName.lastIndexOf('.') + 1)
-    }
 
     private fun parseData(poolId: DevicePoolId, device: DeviceInfo): List<Data> {
         val executions = testResultSerializer.readTests(poolId, device)
@@ -23,7 +20,7 @@ class TimelineSummarySerializer(private val testResultSerializer: TestResultRepo
     }
 
     private fun convertToData(testResult: TestResult): Data {
-        val preparedTestName = prepareTestName(testResult.test.toString())
+        val preparedTestName = testResult.test.toSimpleSafeTestName()
         val testMetric = getTestMetric(testResult)
         return createData(testResult, testResult.status, preparedTestName, testMetric)
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/debug/timeline/TimelineSummarySerializer.kt
@@ -1,31 +1,24 @@
 package com.malinskiy.marathon.report.debug.timeline
 
-import com.malinskiy.marathon.device.DeviceInfo
-import com.malinskiy.marathon.device.DevicePoolId
-import com.malinskiy.marathon.execution.TestResult
+import com.malinskiy.marathon.analytics.tracker.local.RawTestResultTracker
 import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.PoolSummary
 import com.malinskiy.marathon.report.Summary
-import com.malinskiy.marathon.report.internal.TestResultReporter
 import com.malinskiy.marathon.test.Test
-import com.malinskiy.marathon.test.toSimpleSafeTestName
 
-class TimelineSummarySerializer(private val testResultSerializer: TestResultReporter) {
+class TimelineSummarySerializer(private val rawTestResultTracker: RawTestResultTracker) {
     val logger = MarathonLogging.logger(TimelineSummarySerializer::class.java.simpleName)
 
-    private fun parseData(poolId: DevicePoolId, device: DeviceInfo): List<Data> {
-        val executions = testResultSerializer.readTests(poolId, device)
-        return executions
-                .filter { it.isTimeInfoAvailable } //Used for INCOMPLETE tests
-                .map { this.convertToData(it) }
+    private fun parseData(runs: List<RawTestResultTracker.RawTestRun>): List<Data> {
+        return runs.map { this.convertToData(it) }
                 .sortedBy { it.startDate }
     }
 
-    private fun convertToData(testResult: TestResult): Data {
-        val preparedTestName = testResult.test.toSimpleSafeTestName()
+    private fun convertToData(testResult: RawTestResultTracker.RawTestRun): Data {
+        val preparedTestName = "${testResult.clazz}.${testResult.method}"
         val testMetric = getTestMetric(testResult)
-        return createData(testResult, testResult.status, preparedTestName, testMetric)
+        return createData(testResult, testResult.success, preparedTestName, testMetric)
     }
 
     private fun TestStatus.toStatus(): Status = when (this) {
@@ -38,15 +31,15 @@ class TimelineSummarySerializer(private val testResultSerializer: TestResultRepo
 
     data class TestMetric(val expectedValue: Double, val variance: Double)
 
-    private fun createData(execution: TestResult, status: TestStatus, preparedTestName: String, testMetric: TestMetric): Data {
+    private fun createData(execution: RawTestResultTracker.RawTestRun, status: Boolean, preparedTestName: String, testMetric: TestMetric): Data {
         return Data(preparedTestName,
-                status.toStatus(),
-                execution.startTime,
-                execution.endTime,
+                if (status) Status.PASSED else Status.FAILURE,
+                execution.timestamp,
+                execution.timestamp + execution.duration,
                 testMetric.expectedValue, testMetric.variance)
     }
 
-    private fun getTestMetric(execution: TestResult): TestMetric {
+    private fun getTestMetric(execution: RawTestResultTracker.RawTestRun): TestMetric {
         return TestMetric(0.0, 0.0)
     }
 
@@ -67,20 +60,6 @@ class TimelineSummarySerializer(private val testResultSerializer: TestResultRepo
             acc + (list[1].startDate - list[0].endDate)
         })
     }
-
-    private fun parsePoolSummary(poolSummary: PoolSummary): List<Measure> {
-        return poolSummary.tests
-                .map { it.device }
-                .distinct()
-                .map { createMeasure(poolSummary.poolId, it) }
-    }
-
-    private fun createMeasure(pool: DevicePoolId, device: DeviceInfo): Measure {
-        val data = parseData(pool, device)
-        return Measure(device.serialNumber, calculateExecutionStats(data), data)
-    }
-
-    private fun parseList(pools: List<PoolSummary>): List<Measure> = pools.flatMap { this.parsePoolSummary(it) }
 
     private fun extractIdentifiers(summary: PoolSummary): List<Test> {
         return summary.tests
@@ -108,9 +87,16 @@ class TimelineSummarySerializer(private val testResultSerializer: TestResultRepo
 
     fun parse(summary: Summary): ExecutionResult {
         logger.debug { summary }
-        val failedTests = summary.pools.sumBy { it.failed }
-        val passedTestCount = passedTestCount(summary)
-        val measures = parseList(summary.pools)
+
+        val passedTestCount = rawTestResultTracker.testResults.count { it.success }
+        val failedTests = rawTestResultTracker.testResults.count { !it.success }
+
+        val measures = rawTestResultTracker.testResults.groupBy { it.deviceSerial }
+                .map {
+                    val data = parseData(it.value)
+                    Measure(it.key, calculateExecutionStats(data), data)
+                }
+
         logger.debug { measures }
         val executionStats = aggregateExecutionStats(measures)
         logger.debug { executionStats }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
@@ -64,7 +64,7 @@ class JUnitReporter(private val fileManager: FileManager) {
                         }
                         TestStatus.INCOMPLETE, TestStatus.FAILURE -> {
                             element("failure") {
-                                writeCData(testResult.stacktrace!!)
+                                writeCData(testResult.stacktrace ?: "")
                             }
                         }
                         else -> {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
@@ -62,7 +62,7 @@ class JUnitReporter(private val fileManager: FileManager) {
                                 }
                             }
                         }
-                        TestStatus.FAILURE -> {
+                        TestStatus.INCOMPLETE, TestStatus.FAILURE -> {
                             element("failure") {
                                 writeCData(testResult.stacktrace!!)
                             }

--- a/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
@@ -21,4 +21,5 @@ data class Test(val pkg: String,
 }
 
 fun Test.toTestName(): String = "$pkg.$clazz#$method"
+fun Test.toSimpleSafeTestName(): String = "$clazz.$method"
 fun Test.toSafeTestName(): String = "$pkg.$clazz.$method"

--- a/core/src/test/kotlin/com/malinskiy/marathon/MetricsProviderStub.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/MetricsProviderStub.kt
@@ -4,14 +4,17 @@ import com.malinskiy.marathon.analytics.metrics.MetricsProvider
 import com.malinskiy.marathon.test.Test
 import java.time.Instant
 
-class MetricsProviderStub(val successRate: Double = 0.5,
+class MetricsProviderStub(val successRates: Map<Test, Double> = emptyMap(),
+                          val executionTimes: Map<Test, Double> = emptyMap(),
+                          val successRate: Double = 0.5,
                           val executionTime: Double = 1500.0) : MetricsProvider {
+
     override fun successRate(test: Test, limit: Instant): Double {
-        return successRate
+        return successRates[test] ?: successRate
     }
 
     override fun executionTime(test: Test, percentile: Double, limit: Instant): Double {
-        return executionTime
+        return executionTimes[test] ?: executionTime
     }
 
     override fun close() { }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/FixedSizeBatchingStrategySpek.kt
@@ -1,6 +1,9 @@
 package com.malinskiy.marathon.execution.strategy.impl.batching
 
 import com.malinskiy.marathon.TestGenerator
+import com.malinskiy.marathon.analytics.Analytics
+import com.malinskiy.marathon.analytics.metrics.NoOpMetricsProvider
+import com.malinskiy.marathon.analytics.tracker.NoOpTracker
 import org.amshove.kluent.shouldBe
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -8,17 +11,20 @@ import org.jetbrains.spek.api.dsl.it
 import java.util.*
 
 class FixedSizeBatchingStrategySpek : Spek({
+
+    val analytics = Analytics(NoOpTracker(), NoOpMetricsProvider())
+
     describe("test batching strategy with fixed size") {
         it("should create 5 batches for 50 tests with batch size 10") {
             val tests = LinkedList(TestGenerator().create(50))
             val strategy = FixedSizeBatchingStrategy(10)
-            val batch = strategy.process(tests)
+            val batch = strategy.process(tests, analytics)
             batch.tests.size shouldBe 10
         }
         it("should create 1 batch for 10 tests with batch size 10") {
             val tests = LinkedList(TestGenerator().create(10))
             val strategy = FixedSizeBatchingStrategy(10)
-            val batch = strategy.process(tests)
+            val batch = strategy.process(tests, analytics)
             batch.tests.size shouldBe 10
         }
     }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/IsolateBatchingStrategySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/batching/IsolateBatchingStrategySpek.kt
@@ -1,6 +1,9 @@
 package com.malinskiy.marathon.execution.strategy.impl.batching
 
 import com.malinskiy.marathon.TestGenerator
+import com.malinskiy.marathon.analytics.Analytics
+import com.malinskiy.marathon.analytics.metrics.NoOpMetricsProvider
+import com.malinskiy.marathon.analytics.tracker.NoOpTracker
 import com.malinskiy.marathon.test.Test
 import org.amshove.kluent.shouldBe
 import org.jetbrains.spek.api.Spek
@@ -9,6 +12,9 @@ import org.jetbrains.spek.api.dsl.it
 import java.util.*
 
 class IsolateBatchingStrategySpek : Spek({
+
+    val analytics = Analytics(NoOpTracker(), NoOpMetricsProvider())
+
     describe("isolate batching strategy test") {
         it("should return batches with size = 1") {
             val strategy = IsolateBatchingStrategy()
@@ -16,11 +22,11 @@ class IsolateBatchingStrategySpek : Spek({
             val tests = TestGenerator().create(50)
             queue.addAll(tests)
             queue.size shouldBe 50
-            strategy.process(queue).tests.size shouldBe 1
+            strategy.process(queue, analytics).tests.size shouldBe 1
             queue.size shouldBe 49
-            strategy.process(queue).tests.size shouldBe 1
+            strategy.process(queue, analytics).tests.size shouldBe 1
             queue.size shouldBe 48
-            strategy.process(queue).tests.size shouldBe 1
+            strategy.process(queue, analytics).tests.size shouldBe 1
             queue.size shouldBe 47
         }
     }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/strategy/impl/sorting/ExecutionTimeSortingStrategySpek.kt
@@ -1,0 +1,37 @@
+package com.malinskiy.marathon.execution.strategy.impl.sorting
+
+import com.malinskiy.marathon.MetricsProviderStub
+import com.malinskiy.marathon.TestGenerator
+import com.malinskiy.marathon.execution.TestShard
+import org.amshove.kluent.shouldBe
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class ExecutionTimeSortingStrategySpek : Spek({
+    describe("execution-time-sorting-strategy test") {
+        val instant = Instant.now()
+        context("strategy with min success rate 0.8") {
+            val strategy = ExecutionTimeSortingStrategy(0.8, Instant.now().minus(1, ChronoUnit.DAYS))
+            group("single test shard") {
+                val tests = TestGenerator().create(3)
+                val testShard = TestShard(tests)
+                it("should return 3 tests sorted by execution time") {
+                    val metricsProvider = MetricsProviderStub(
+                            executionTimes = testShard.tests.mapIndexed { index, test ->
+                                Pair(test, 1000.0 + index * 1000.0)
+                            }.toMap()
+                    )
+                    val result = testShard.tests.sortedWith(strategy.process(metricsProvider))
+                    result.size shouldBe 3
+                    result[0] shouldBe tests[2]
+                    result[1] shouldBe tests[1]
+                    result[2] shouldBe tests[0]
+                }
+            }
+        }
+    }
+})

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/BatchingStrategyConfiguration.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/BatchingStrategyConfiguration.kt
@@ -25,8 +25,9 @@ class FixedSizeBatchingStrategyConfiguration {
     var durationMillis: Long? = null
     var percentile: Double? = null
     var timeLimit: Instant? = null
+    var lastMileLength: Int = 0
 }
 
 fun BatchingStrategyConfiguration.toStrategy(): BatchingStrategy = fixedSize?.let {
-    FixedSizeBatchingStrategy(it.size, it.durationMillis, it.percentile, it.timeLimit)
+    FixedSizeBatchingStrategy(it.size, it.durationMillis, it.percentile, it.timeLimit, it.lastMileLength)
 } ?: IsolateBatchingStrategy()

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/BatchingStrategyConfiguration.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/BatchingStrategyConfiguration.kt
@@ -4,6 +4,7 @@ import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.batching.IsolateBatchingStrategy
 import groovy.lang.Closure
+import java.time.Instant
 
 class BatchingStrategyConfiguration {
     var fixedSize: FixedSizeBatchingStrategyConfiguration? = null
@@ -21,8 +22,11 @@ class BatchingStrategyConfiguration {
 
 class FixedSizeBatchingStrategyConfiguration {
     var size = 1
+    var durationMillis: Long? = null
+    var percentile: Double? = null
+    var timeLimit: Instant? = null
 }
 
 fun BatchingStrategyConfiguration.toStrategy(): BatchingStrategy = fixedSize?.let {
-    FixedSizeBatchingStrategy(it.size)
+    FixedSizeBatchingStrategy(it.size, it.durationMillis, it.percentile, it.timeLimit)
 } ?: IsolateBatchingStrategy()

--- a/sample-app/buildSrc/buildSrc.iml
+++ b/sample-app/buildSrc/buildSrc.iml
@@ -37,6 +37,7 @@
               <option value="$KOTLIN_BUNDLED$/lib/sam-with-receiver-compiler-plugin.jar" />
             </array>
           </option>
+          <option name="coroutinesState" value="warn" />
         </compilerArguments>
       </configuration>
     </facet>

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
@@ -101,7 +101,7 @@ class AndroidDevice(val ddmsDevice: IDevice) : Device {
     private fun clearLogcat(device: IDevice) {
         val logger = MarathonLogging.logger("AndroidDevice.clearLogcat")
         try {
-            device.executeShellCommand("logcat -c", NullOutputReceiver())
+            device.safeExecuteShellCommand("logcat -c", NullOutputReceiver())
         } catch (e: Throwable) {
             logger.warn("Could not clear logcat on device: ${device.serialNumber}", e)
         }

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
@@ -91,7 +91,7 @@ class AndroidDevice(val ddmsDevice: IDevice) : Device {
     override fun prepare(configuration: Configuration) {
         if (!waitForBoot()) throw TimeoutException("Timeout waiting for device $serialNumber to boot")
 
-        AndroidAppInstaller(configuration).prepareInstallation(ddmsDevice)
+        AndroidAppInstaller(configuration).prepareInstallation(this)
         RemoteFileManager.removeRemoteDirectory(ddmsDevice)
         RemoteFileManager.createRemoteDirectory(ddmsDevice)
         clearLogcat(ddmsDevice)

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
@@ -85,6 +85,11 @@ class AndroidDevice(val ddmsDevice: IDevice) : Device {
     }
 
     override fun prepare(configuration: Configuration) {
+        while(ddmsDevice.getProperty("sys.boot_completed") == null) {
+            Thread.sleep(1000)
+            if(Thread.interrupted()) return
+        }
+
         AndroidAppInstaller(configuration).prepareInstallation(ddmsDevice)
         RemoteFileManager.removeRemoteDirectory(ddmsDevice)
         RemoteFileManager.createRemoteDirectory(ddmsDevice)

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DdmlibDeviceExtensions.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DdmlibDeviceExtensions.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
 
 const val ADB_INSTALL_TIMEOUT_MINUTES = 4L
 const val ADB_SHORT_TIMEOUT_SECONDS = 20L
-const val ADB_SCREEN_RECORD_TIMOUT = 10L
+const val ADB_SCREEN_RECORD_TIMEOUT = 10L
 
 fun IDevice.safeUninstallPackage(packageName: String): String? {
     try {
@@ -57,7 +57,7 @@ fun IDevice.safeExecuteShellCommand(command: String, receiver: IShellOutputRecei
 
 fun IDevice.safeStartScreenRecorder(remoteFilePath: String, options: ScreenRecorderOptions, receiver: IShellOutputReceiver) {
     val screenRecorderCommand = getScreenRecorderCommand(remoteFilePath, options)
-    executeShellCommand(screenRecorderCommand, receiver, ADB_SCREEN_RECORD_TIMOUT, ADB_SCREEN_RECORD_TIMOUT, TimeUnit.MINUTES)
+    executeShellCommand(screenRecorderCommand, receiver, ADB_SCREEN_RECORD_TIMEOUT, ADB_SCREEN_RECORD_TIMEOUT, TimeUnit.MINUTES)
 }
 
 fun getScreenRecorderCommand(@NonNull remoteFilePath: String,

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DdmlibDeviceExtensions.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DdmlibDeviceExtensions.kt
@@ -1,0 +1,97 @@
+package com.malinskiy.marathon.android
+
+import com.android.annotations.NonNull
+import com.android.ddmlib.AdbCommandRejectedException
+import com.android.ddmlib.IDevice
+import com.android.ddmlib.IShellOutputReceiver
+import com.android.ddmlib.InstallException
+import com.android.ddmlib.InstallReceiver
+import com.android.ddmlib.ScreenRecorderOptions
+import com.android.ddmlib.ShellCommandUnresponsiveException
+import com.android.ddmlib.TimeoutException
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+const val ADB_INSTALL_TIMEOUT_MINUTES = 4L
+const val ADB_SHORT_TIMEOUT_SECONDS = 20L
+const val ADB_SCREEN_RECORD_TIMOUT = 10L
+
+fun IDevice.safeUninstallPackage(packageName: String): String? {
+    try {
+        val receiver = InstallReceiver()
+        executeShellCommand("pm uninstall $packageName",
+                receiver,
+                ADB_INSTALL_TIMEOUT_MINUTES,
+                ADB_INSTALL_TIMEOUT_MINUTES,
+                TimeUnit.MINUTES)
+
+        return receiver.errorMessage
+    } catch (e: TimeoutException) {
+        throw InstallException(e)
+    } catch (e: AdbCommandRejectedException) {
+        throw InstallException(e)
+    } catch (e: ShellCommandUnresponsiveException) {
+        throw InstallException(e)
+    } catch (e: IOException) {
+        throw InstallException(e)
+    }
+}
+
+fun IDevice.safeInstallPackage(packageFilePath: String, reinstall: Boolean, vararg extraArgs: String): String? {
+    val receiver = InstallReceiver()
+
+    installPackage(packageFilePath,
+            reinstall,
+            receiver,
+            ADB_INSTALL_TIMEOUT_MINUTES,
+            ADB_INSTALL_TIMEOUT_MINUTES,
+            TimeUnit.MINUTES,
+            *extraArgs)
+
+    return receiver.errorMessage
+}
+
+fun IDevice.safeExecuteShellCommand(command: String, receiver: IShellOutputReceiver) {
+    executeShellCommand(command, receiver, ADB_SHORT_TIMEOUT_SECONDS, ADB_SHORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+}
+
+fun IDevice.safeStartScreenRecorder(remoteFilePath: String, options: ScreenRecorderOptions, receiver: IShellOutputReceiver) {
+    val screenRecorderCommand = getScreenRecorderCommand(remoteFilePath, options)
+    executeShellCommand(screenRecorderCommand, receiver, ADB_SCREEN_RECORD_TIMOUT, ADB_SCREEN_RECORD_TIMOUT, TimeUnit.MINUTES)
+}
+
+fun getScreenRecorderCommand(@NonNull remoteFilePath: String,
+                             @NonNull options: ScreenRecorderOptions): String {
+    val sb = StringBuilder()
+
+    sb.append("screenrecord")
+    sb.append(' ')
+
+    if (options.width > 0 && options.height > 0) {
+        sb.append("--size ")
+        sb.append(options.width)
+        sb.append('x')
+        sb.append(options.height)
+        sb.append(' ')
+    }
+
+    if (options.bitrateMbps > 0) {
+        sb.append("--bit-rate ")
+        sb.append(options.bitrateMbps * 1000000)
+        sb.append(' ')
+    }
+
+    if (options.timeLimit > 0) {
+        sb.append("--time-limit ")
+        var seconds = TimeUnit.SECONDS.convert(options.timeLimit, options.timeLimitUnits)
+        if (seconds > 180) {
+            seconds = 180
+        }
+        sb.append(seconds)
+        sb.append(' ')
+    }
+
+    sb.append(remoteFilePath)
+
+    return sb.toString()
+}

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
@@ -32,7 +32,7 @@ object RemoteFileManager {
 
     private fun executeCommand(device: IDevice, command: String, errorMessage: String) {
         try {
-            device.executeShellCommand(command, NO_OP_RECEIVER, 20, TimeUnit.SECONDS)
+            device.safeExecuteShellCommand(command, NO_OP_RECEIVER)
         } catch (e: TimeoutException) {
             logger.error(errorMessage, e)
         } catch (e: AdbCommandRejectedException) {

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
@@ -9,6 +9,7 @@ import com.android.ddmlib.testrunner.TestIdentifier
 import com.malinskiy.marathon.log.MarathonLogging
 
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 object RemoteFileManager {
 
@@ -31,7 +32,7 @@ object RemoteFileManager {
 
     private fun executeCommand(device: IDevice, command: String, errorMessage: String) {
         try {
-            device.executeShellCommand(command, NO_OP_RECEIVER)
+            device.executeShellCommand(command, NO_OP_RECEIVER, 20, TimeUnit.SECONDS)
         } catch (e: TimeoutException) {
             logger.error(errorMessage, e)
         } catch (e: AdbCommandRejectedException) {

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
@@ -31,9 +31,9 @@ class AndroidAppInstaller(private val configuration: Configuration) {
     private fun reinstall(device: IDevice, appPackage: String, appApk: File) {
         withRetry(attempts = MAX_RETIRES, delay = 1000) {
             try {
-                logger.info("Uninstalling $appPackage from $device.serialNumber")
+                logger.info("Uninstalling $appPackage from ${device.serialNumber}")
                 device.uninstallPackage(appPackage)
-                logger.info("Installing $appPackage to $device.serialNumber")
+                logger.info("Installing $appPackage to ${device.serialNumber}")
                 device.installPackage(appApk.absolutePath, true, optionalParams(device))
             } catch (e: InstallException) {
                 throw RuntimeException("Error while installing $appPackage on ${device.serialNumber}", e)

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
@@ -40,10 +40,13 @@ class AndroidAppInstaller(configuration: Configuration) {
         withRetry(attempts = MAX_RETIRES, delay = 1000) {
             try {
                 logger.info("Uninstalling $appPackage from ${device.serialNumber}")
-                ddmsDevice.safeUninstallPackage(appPackage)
+                val uninstallMessage = ddmsDevice.safeUninstallPackage(appPackage)
+                uninstallMessage?.let { logger.debug { it } }
                 logger.info("Installing $appPackage to ${device.serialNumber}")
-                ddmsDevice.safeInstallPackage(appApk.absolutePath, true, optionalParams(ddmsDevice))
+                val installMessage = ddmsDevice.safeInstallPackage(appApk.absolutePath, true, optionalParams(ddmsDevice))
+                installMessage?.let { logger.debug { it } }
             } catch (e: InstallException) {
+                logger.error(e) { "Error while installing $appPackage on ${device.serialNumber}" }
                 throw RuntimeException("Error while installing $appPackage on ${device.serialNumber}", e)
             }
         }

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
@@ -11,7 +11,7 @@ import com.malinskiy.marathon.execution.withRetry
 import com.malinskiy.marathon.log.MarathonLogging
 import java.io.File
 
-class AndroidAppInstaller(private val configuration: Configuration) {
+class AndroidAppInstaller(configuration: Configuration) {
 
     companion object {
         private const val MAX_RETIRES = 3
@@ -23,10 +23,13 @@ class AndroidAppInstaller(private val configuration: Configuration) {
 
     fun prepareInstallation(device: IDevice) {
         val applicationInfo = ApkParser().parseInstrumentationInfo(androidConfiguration.testApplicationOutput)
+        logger.debug { "Installing application output to ${device.serialNumber}" }
         androidConfiguration.applicationOutput?.let {
             reinstall(device, applicationInfo.applicationPackage, it)
         }
+        logger.debug { "Installing instrumentation package to ${device.serialNumber}" }
         reinstall(device, applicationInfo.instrumentationPackage, androidConfiguration.testApplicationOutput)
+        logger.debug { "Prepare installation finished for ${device.serialNumber}" }
     }
 
     @Suppress("TooGenericExceptionThrown")

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
@@ -4,6 +4,8 @@ import com.android.ddmlib.IDevice
 import com.android.ddmlib.InstallException
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.ApkParser
+import com.malinskiy.marathon.android.safeInstallPackage
+import com.malinskiy.marathon.android.safeUninstallPackage
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.withRetry
 import com.malinskiy.marathon.log.MarathonLogging
@@ -32,9 +34,9 @@ class AndroidAppInstaller(private val configuration: Configuration) {
         withRetry(attempts = MAX_RETIRES, delay = 1000) {
             try {
                 logger.info("Uninstalling $appPackage from ${device.serialNumber}")
-                device.uninstallPackage(appPackage)
+                device.safeUninstallPackage(appPackage)
                 logger.info("Installing $appPackage to ${device.serialNumber}")
-                device.installPackage(appApk.absolutePath, true, optionalParams(device))
+                device.safeInstallPackage(appApk.absolutePath, true, optionalParams(device))
             } catch (e: InstallException) {
                 throw RuntimeException("Error while installing $appPackage on ${device.serialNumber}", e)
             }

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
@@ -55,7 +55,7 @@ class AndroidDeviceTestRunner(private val device: AndroidDevice) {
                 listOf(
                         TestRunResultsListener(testBatch, device, deferred),
                         ScreenRecorderTestRunListener(fileManager, devicePoolId, device),
-                        DebugTestRunListener(device.ddmsDevice),
+                        DebugTestRunListener(device),
                         ProgressTestRunListener(device, devicePoolId, progressReporter),
                         LogCatListener(device, devicePoolId, LogWriter(fileManager))
                 )

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
@@ -14,6 +14,7 @@ import com.malinskiy.marathon.android.executor.listeners.ProgressTestRunListener
 import com.malinskiy.marathon.android.executor.listeners.video.ScreenRecorderTestRunListener
 import com.malinskiy.marathon.android.executor.listeners.TestRunResultsListener
 import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.exceptions.TestBatchExecutionException
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.TestBatchResults
 import com.malinskiy.marathon.execution.progress.ProgressReporter
@@ -50,23 +51,29 @@ class AndroidDeviceTestRunner(private val device: AndroidDevice) {
 
         runner.setClassNames(tests)
         val fileManager = FileManager(configuration.outputDir)
-        val listeners = CompositeTestRunListener(listOf(
-                TestRunResultsListener(testBatch, device, deferred),
-                ScreenRecorderTestRunListener(fileManager, devicePoolId, device),
-                DebugTestRunListener(device.ddmsDevice),
-                ProgressTestRunListener(device, devicePoolId, progressReporter),
-                LogCatListener(device, devicePoolId, LogWriter(fileManager)))
+        val listeners = CompositeTestRunListener(
+                listOf(
+                        TestRunResultsListener(testBatch, device, deferred),
+                        ScreenRecorderTestRunListener(fileManager, devicePoolId, device),
+                        DebugTestRunListener(device.ddmsDevice),
+                        ProgressTestRunListener(device, devicePoolId, progressReporter),
+                        LogCatListener(device, devicePoolId, LogWriter(fileManager))
+                )
         )
         try {
             runner.run(listeners)
         } catch (e: ShellCommandUnresponsiveException) {
             logger.warn("Test got stuck. You can increase the timeout in settings if it's too strict")
+            throw TestBatchExecutionException(e)
         } catch (e: TimeoutException) {
             logger.warn("Test got stuck. You can increase the timeout in settings if it's too strict")
+            throw TestBatchExecutionException(e)
         } catch (e: AdbCommandRejectedException) {
-            throw RuntimeException("Error while running tests ${testBatch.tests.map { it.toTestName() }}", e)
+            logger.error { "Error while running tests ${testBatch.tests.map { it.toTestName() }}" }
+            throw TestBatchExecutionException(e)
         } catch (e: IOException) {
-            throw RuntimeException("Error while running tests ${testBatch.tests.map { it.toTestName() }}", e)
+            logger.error { "Error while running tests ${testBatch.tests.map { it.toTestName() }}" }
+            throw TestBatchExecutionException(e)
         } finally {
 
         }

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidDeviceTestRunner.kt
@@ -69,10 +69,10 @@ class AndroidDeviceTestRunner(private val device: AndroidDevice) {
             logger.warn("Test got stuck. You can increase the timeout in settings if it's too strict")
             throw TestBatchExecutionException(e)
         } catch (e: AdbCommandRejectedException) {
-            logger.error { "Error while running tests ${testBatch.tests.map { it.toTestName() }}" }
+            logger.error(e) { "adb error while running tests ${testBatch.tests.map { it.toTestName() }}" }
             throw TestBatchExecutionException(e)
         } catch (e: IOException) {
-            logger.error { "Error while running tests ${testBatch.tests.map { it.toTestName() }}" }
+            logger.error(e) { "Error while running tests ${testBatch.tests.map { it.toTestName() }}" }
             throw TestBatchExecutionException(e)
         } finally {
 

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/DebugTestRunListener.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/DebugTestRunListener.kt
@@ -1,11 +1,11 @@
 package com.malinskiy.marathon.android.executor.listeners
 
-import com.android.ddmlib.IDevice
 import com.android.ddmlib.testrunner.ITestRunListener
 import com.android.ddmlib.testrunner.TestIdentifier
+import com.malinskiy.marathon.android.AndroidDevice
 import com.malinskiy.marathon.log.MarathonLogging
 
-class DebugTestRunListener(private val device: IDevice) : ITestRunListener {
+class DebugTestRunListener(private val device: AndroidDevice) : ITestRunListener {
 
     private val logger = MarathonLogging.logger("DebugTestRunListener")
 

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -46,7 +46,7 @@ class TestRunResultsListener(private val testBatch: TestBatch,
 
         if (skipped.isNotEmpty()) {
             skipped.forEach {
-                logger.warn { "skipped = ${it.test.toTestName()}" }
+                logger.warn { "skipped = ${it.test.toTestName()}, ${device.serialNumber}" }
             }
         }
 

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -6,15 +6,14 @@ import com.malinskiy.marathon.android.toTest
 import com.malinskiy.marathon.device.Device
 import com.malinskiy.marathon.device.toDeviceInfo
 import com.malinskiy.marathon.execution.TestBatchResults
+import com.malinskiy.marathon.execution.TestResult
+import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
-import com.malinskiy.marathon.execution.TestResult
-import com.malinskiy.marathon.execution.TestStatus
-import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.toTestName
 import kotlinx.coroutines.experimental.CompletableDeferred
-import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 import com.android.ddmlib.testrunner.TestResult as DdmLibTestResult
+import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 
 class TestRunResultsListener(private val testBatch: TestBatch,
                              private val device: Device,
@@ -40,17 +39,15 @@ class TestRunResultsListener(private val testBatch: TestBatch,
 
         val skipped = tests.filterNot {
             results.containsKey(it.key)
-        }.values.map {
-            TestResult(it, device.toDeviceInfo(), TestStatus.INCOMPLETE, 0, 0, null)
-        }
+        }.values
 
         if (skipped.isNotEmpty()) {
             skipped.forEach {
-                logger.warn { "skipped = ${it.test.toTestName()}, ${device.serialNumber}" }
+                logger.warn { "skipped = ${it.toTestName()}, ${device.serialNumber}" }
             }
         }
 
-        deferred.complete(TestBatchResults(device, finished, failed + skipped))
+        deferred.complete(TestBatchResults(device, finished, failed, skipped))
     }
 
     fun Map.Entry<TestIdentifier, DdmLibTestResult>.toTestResult(device: Device): TestResult {

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorder.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorder.kt
@@ -5,6 +5,7 @@ import com.android.ddmlib.IDevice
 import com.android.ddmlib.ScreenRecorderOptions
 import com.android.ddmlib.testrunner.TestIdentifier
 import com.malinskiy.marathon.android.RemoteFileManager
+import com.malinskiy.marathon.android.safeStartScreenRecorder
 import com.malinskiy.marathon.log.MarathonLogging
 import java.util.concurrent.TimeUnit.SECONDS
 import kotlin.system.measureTimeMillis
@@ -25,7 +26,7 @@ internal class ScreenRecorder(private val device: IDevice,
 
     private fun startRecordingTestVideo() {
         val millis = measureTimeMillis {
-            device.startScreenRecorder(remoteFilePath, options, receiver)
+            device.safeStartScreenRecorder(remoteFilePath, options, receiver)
         }
         logger.trace { "Recording finished in ${millis}ms $remoteFilePath" }
     }

--- a/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderStopper.kt
+++ b/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderStopper.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.android.executor.listeners.video
 
 import com.android.ddmlib.IDevice
 import com.android.ddmlib.NullOutputReceiver
+import com.malinskiy.marathon.android.safeExecuteShellCommand
 import com.malinskiy.marathon.log.MarathonLogging
 
 internal class ScreenRecorderStopper(private val deviceInterface: IDevice) {
@@ -19,11 +20,11 @@ internal class ScreenRecorderStopper(private val deviceInterface: IDevice) {
     private fun attemptToGracefullyKillScreenRecord(): Boolean {
         val receiver = CollectingShellOutputReceiver()
         try {
-            deviceInterface.executeShellCommand("ps |grep screenrecord", receiver)
+            deviceInterface.safeExecuteShellCommand("ps |grep screenrecord", receiver)
             val pid = extractPidOfScreenRecordProcess(receiver)
             if (pid.isNotBlank()) {
                 logger.trace("Killing PID {} on {}", pid, deviceInterface.serialNumber)
-                deviceInterface.executeShellCommand("kill -2 $pid", nullOutputReceiver)
+                deviceInterface.safeExecuteShellCommand("kill -2 $pid", nullOutputReceiver)
                 return true
             }
             logger.trace("Did not kill any screen recording process")

--- a/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
+++ b/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
@@ -7,8 +7,6 @@ import com.malinskiy.marathon.execution.TestBatchResults
 import com.malinskiy.marathon.execution.TestResult
 import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.execution.progress.ProgressReporter
-import com.malinskiy.marathon.ios.IOSDevice
-import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import com.malinskiy.marathon.test.toSafeTestName
@@ -31,11 +29,7 @@ class ProgressReportingListener(private val device: Device,
             !received.contains(it.toSafeTestName())
         }
 
-        val incomplete = incompleteTests.map {
-            TestResult(it, device.toDeviceInfo(), TestStatus.INCOMPLETE, 0, 0, null)
-        }
-
-        deferred.complete(TestBatchResults(device, success, failure + incomplete))
+        deferred.complete(TestBatchResults(device, success, failure, incompleteTests))
     }
 
     override fun testFailed(test: Test, startTime: Long, endTime: Long) {


### PR DESCRIPTION
List of fixes:
- Sometimes device termination leads to active batch present. First terminate the device then return batch
- In order to easily dogfood simplify custom deployments
- Logging was not present in gradle plugin case. Workaround by outputting to warn level
- Add more logs to some steps
- AndroidDevice provider shouldn't create another instance if a device with the same serial was already observed
- Timeline should now have proper test names, include test retires to better understand what happened during the run
- ExecutionTimeSortingStrategy now has 1 test :)
- Fix bug with retention policy not applied to all InfluxDB instances