### PR TITLE
Adding composition filter

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
@@ -8,7 +8,13 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.malinskiy.marathon.exceptions.ConfigurationException
-import com.malinskiy.marathon.execution.*
+import com.malinskiy.marathon.execution.AnnotationFilter
+import com.malinskiy.marathon.execution.CompositionFilter
+import com.malinskiy.marathon.execution.FullyQualifiedClassnameFilter
+import com.malinskiy.marathon.execution.SimpleClassnameFilter
+import com.malinskiy.marathon.execution.TestFilter
+import com.malinskiy.marathon.execution.TestMethodFilter
+import com.malinskiy.marathon.execution.TestPackageFilter
 
 class TestFilterDeserializer : StdDeserializer<TestFilter>(TestFilter::class.java) {
     override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): TestFilter {

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
@@ -8,12 +8,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.malinskiy.marathon.exceptions.ConfigurationException
-import com.malinskiy.marathon.execution.AnnotationFilter
-import com.malinskiy.marathon.execution.FullyQualifiedClassnameFilter
-import com.malinskiy.marathon.execution.SimpleClassnameFilter
-import com.malinskiy.marathon.execution.TestFilter
-import com.malinskiy.marathon.execution.TestMethodFilter
-import com.malinskiy.marathon.execution.TestPackageFilter
+import com.malinskiy.marathon.execution.*
 
 class TestFilterDeserializer : StdDeserializer<TestFilter>(TestFilter::class.java) {
     override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): TestFilter {
@@ -42,6 +37,11 @@ class TestFilterDeserializer : StdDeserializer<TestFilter>(TestFilter::class.jav
                 (node as ObjectNode).remove("type")
                 codec.treeToValue<TestMethodFilter>(node)
             }
+            "composition" -> {
+                (node as ObjectNode).remove("type")
+                codec.treeToValue<CompositionFilter>(node)
+            }
+
             else -> throw ConfigurationException("Unrecognized filter type $type")
         }
     }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -10,7 +10,13 @@ import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
 import com.malinskiy.marathon.exceptions.ConfigurationException
-import com.malinskiy.marathon.execution.*
+import com.malinskiy.marathon.execution.AnalyticsConfiguration
+import com.malinskiy.marathon.execution.AnnotationFilter
+import com.malinskiy.marathon.execution.CompositionFilter
+import com.malinskiy.marathon.execution.FullyQualifiedClassnameFilter
+import com.malinskiy.marathon.execution.SimpleClassnameFilter
+import com.malinskiy.marathon.execution.TestMethodFilter
+import com.malinskiy.marathon.execution.TestPackageFilter
 import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.batching.IsolateBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.flakiness.IgnoreFlakinessStrategy

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -10,12 +10,7 @@ import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
 import com.malinskiy.marathon.exceptions.ConfigurationException
-import com.malinskiy.marathon.execution.AnalyticsConfiguration
-import com.malinskiy.marathon.execution.AnnotationFilter
-import com.malinskiy.marathon.execution.FullyQualifiedClassnameFilter
-import com.malinskiy.marathon.execution.SimpleClassnameFilter
-import com.malinskiy.marathon.execution.TestMethodFilter
-import com.malinskiy.marathon.execution.TestPackageFilter
+import com.malinskiy.marathon.execution.*
 import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.batching.IsolateBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.flakiness.IgnoreFlakinessStrategy
@@ -40,7 +35,6 @@ import org.amshove.kluent.`should be instance of`
 import org.amshove.kluent.mock
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEmpty
-import org.amshove.kluent.shouldBeInRange
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldNotThrow
@@ -110,7 +104,9 @@ object ConfigFactorySpec : Spek({
                 configuration.filteringConfiguration.whitelist shouldContainAll listOf(
                         SimpleClassnameFilter(".*".toRegex()),
                         FullyQualifiedClassnameFilter(".*".toRegex()),
-                        TestMethodFilter(".*".toRegex())
+                        TestMethodFilter(".*".toRegex()),
+                        CompositionFilter(listOf(TestPackageFilter(".*".toRegex()),
+                                TestMethodFilter(".*".toRegex())), CompositionFilter.OPERATION.UNION)
                 )
 
                 configuration.filteringConfiguration.blacklist shouldContainAll listOf(

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -38,6 +38,13 @@ filteringConfiguration:
     regex: ".*"
   - type: "method"
     regex: ".*"
+  - type: "composition"
+    filters:
+    - type: "package"
+      regex: ".*"
+    - type: "method"
+      regex: ".*"
+    op: "UNION"
   blacklist:
   - type: "package"
     regex: ".*"

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
@@ -21,7 +21,7 @@ class CompositionFilter(private val filters: List<TestFilter>, private val op: O
     }
 
     private fun filterWithUnionOperation(tests: List<Test>): List<Test> {
-        return  filters.fold(emptySet<Test>()) { acc, f ->
+        return filters.fold(emptySet<Test>()) { acc, f ->
             acc.union(f.filter(tests))
         }.toList()
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
@@ -1,0 +1,32 @@
+package com.malinskiy.marathon.execution
+
+import com.malinskiy.marathon.test.Test
+
+class CompositionFilter(val filters: Array<TestFilter>, private val op: OPERATION) : TestFilter {
+    override fun filter(tests: List<Test>): List<Test> {
+        var initial = filters[0].filter(tests)
+        filters.forEach {
+            initial = when (op) {
+                OPERATION.UNION -> initial.union(it.filter(tests)).toList()
+                OPERATION.INTERSECTION -> initial.intersect(it.filter(tests)).toList()
+            }
+        }
+        return initial
+    }
+
+    override fun filterNot(tests: List<Test>): List<Test> {
+        var initial = filters[0].filterNot(tests)
+        filters.forEach {
+            initial = when (op) {
+                OPERATION.UNION -> initial.union(it.filterNot(tests)).toList()
+                OPERATION.INTERSECTION -> initial.intersect(it.filterNot(tests)).toList()
+            }
+        }
+        return initial
+    }
+
+    enum class OPERATION {
+        UNION,
+        INTERSECTION
+    }
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
@@ -1,8 +1,10 @@
 package com.malinskiy.marathon.execution
 
+import com.google.gson.annotations.SerializedName
 import com.malinskiy.marathon.test.Test
 
-class CompositionFilter(private val filters: List<TestFilter>, private val op: OPERATION) : TestFilter {
+class CompositionFilter(@SerializedName("filters") private val filters: List<TestFilter>,
+                        @SerializedName("op") private val op: OPERATION) : TestFilter {
     override fun filter(tests: List<Test>): List<Test> {
         return when (op) {
             OPERATION.UNION -> filterWithUnionOperation(tests)
@@ -39,6 +41,18 @@ class CompositionFilter(private val filters: List<TestFilter>, private val op: O
 
         }.toList()
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is CompositionFilter) return false
+        if (filters.count() != other.filters.count()) return false
+        if (op != other.op) return false
+        filters.forEach {
+            if (!other.filters.contains(it)) return false
+        }
+        return true
+    }
+
+    override fun hashCode(): Int = filters.hashCode() + op.hashCode()
 
     enum class OPERATION {
         UNION,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
@@ -7,7 +7,7 @@ class CompositionFilter(private val filters: List<TestFilter>, private val op: O
         return when (op) {
             OPERATION.UNION -> filterWithUnionOperation(tests)
             OPERATION.INTERSECTION -> filterWithIntersectionOperation(tests)
-            OPERATION.SUBTRACT -> filterWithSubstractOperation(tests)
+            OPERATION.SUBTRACT -> filterWithSubtractOperation(tests)
         }
     }
 
@@ -21,28 +21,23 @@ class CompositionFilter(private val filters: List<TestFilter>, private val op: O
     }
 
     private fun filterWithUnionOperation(tests: List<Test>): List<Test> {
-        var filteredTests = filters[0].filter(tests)
-        filters.drop(1).forEach {
-            filteredTests = filteredTests.union(it.filter(tests)).toList()
-        }
-        return filteredTests
+        return  filters.fold(emptySet<Test>()) { acc, f ->
+            acc.union(f.filter(tests))
+        }.toList()
     }
 
     private fun filterWithIntersectionOperation(tests: List<Test>): List<Test> {
-        var filteredTests = filters[0].filter(tests)
-        filters.drop(1).forEach {
-            filteredTests = tests.intersect(it.filter(filteredTests)).toList()
-        }
-        return filteredTests
+        return filters.fold(tests.toSet()) { acc, f ->
+            acc.intersect(f.filter(tests))
+        }.toList()
     }
 
 
-    private fun filterWithSubstractOperation(tests: List<Test>): List<Test> {
-        var filteredTests = filters[0].filter(tests)
-        filters.drop(1).forEach {
-            filteredTests = tests.subtract(it.filter(filteredTests)).toList()
-        }
-        return filteredTests
+    private fun filterWithSubtractOperation(tests: List<Test>): List<Test> {
+        return filters.fold(tests.toSet()) { acc, f ->
+            acc.subtract(f.filter(tests))
+
+        }.toList()
     }
 
     enum class OPERATION {

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/CompositionFilterSpec.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/CompositionFilterSpec.kt
@@ -1,0 +1,64 @@
+package com.malinskiy.marathon.execution
+
+import com.malinskiy.marathon.test.Test
+import org.amshove.kluent.shouldEqual
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+
+object CompositionFilterSpec : Spek({
+    val dogTest = stubTest("FilterAnimalDogTest", "com.example.BestAnimal")
+    val catTest = stubTest("FilterAnimalCatTest", "")
+    val horseTest = stubTest("FilterAnimalHorseTest", "")
+
+
+    given("a CompositionFilter with different Filters and Union Operation") {
+        val filterUnion = CompositionFilter(
+                arrayOf(
+                        SimpleClassnameFilter("Cat".toRegex()),
+                        AnnotationFilter("""com\.example\.BestAnimal.*""".toRegex())),
+                CompositionFilter.OPERATION.UNION)
+
+        on("a bunch of tests") {
+            val tests = listOf(
+                    dogTest,
+                    catTest,
+                    horseTest
+            )
+            it("should filter properly the union") {
+                filterUnion.filter(tests) shouldEqual listOf(dogTest, catTest)
+            }
+            it("should filterNot properly the union") {
+                filterUnion.filterNot(tests) shouldEqual listOf(horseTest)
+            }
+        }
+    }
+
+    given("a CompositionFilter with different Filters and Intersection Operation") {
+        val filterUnion = CompositionFilter(
+                arrayOf(
+                        SimpleClassnameFilter("Dog".toRegex()),
+                        SimpleClassnameFilter("Cat".toRegex())),
+                CompositionFilter.OPERATION.INTERSECTION)
+
+        on("a bunch of tests") {
+            val tests = listOf(
+                    dogTest,
+                    catTest,
+                    horseTest
+            )
+            it("should filter properly the union") {
+                filterUnion.filter(tests) shouldEqual emptyList()
+            }
+            it("should filterNot properly the union") {
+                filterUnion.filterNot(tests) shouldEqual listOf(dogTest, catTest, horseTest)
+            }
+        }
+    }
+
+
+})
+
+private fun stubTest(className: String,
+                     vararg annotations: String) = Test("com.example", className, "fakeMethod", listOf(*annotations))

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/CompositionFilterSpec.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/CompositionFilterSpec.kt
@@ -15,9 +15,9 @@ object CompositionFilterSpec : Spek({
 
     given("a CompositionFilter with different Filters and Union Operation") {
         val filterUnion = CompositionFilter(
-                arrayOf(
-                        SimpleClassnameFilter("Cat".toRegex()),
-                        AnnotationFilter("""com\.example\.BestAnimal.*""".toRegex())),
+                listOf(
+                        SimpleClassnameFilter(".*Cat.*".toRegex()),
+                        AnnotationFilter("com.example.BestAnimal".toRegex())),
                 CompositionFilter.OPERATION.UNION)
 
         on("a bunch of tests") {
@@ -27,7 +27,7 @@ object CompositionFilterSpec : Spek({
                     horseTest
             )
             it("should filter properly the union") {
-                filterUnion.filter(tests) shouldEqual listOf(dogTest, catTest)
+                filterUnion.filter(tests) shouldEqual listOf(catTest, dogTest)
             }
             it("should filterNot properly the union") {
                 filterUnion.filterNot(tests) shouldEqual listOf(horseTest)
@@ -36,10 +36,10 @@ object CompositionFilterSpec : Spek({
     }
 
     given("a CompositionFilter with different Filters and Intersection Operation") {
-        val filterUnion = CompositionFilter(
-                arrayOf(
-                        SimpleClassnameFilter("Dog".toRegex()),
-                        SimpleClassnameFilter("Cat".toRegex())),
+        val filterIntersection = CompositionFilter(
+                listOf(
+                        SimpleClassnameFilter(".*Dog.*".toRegex()),
+                        AnnotationFilter("com.example.BestAnimal".toRegex())),
                 CompositionFilter.OPERATION.INTERSECTION)
 
         on("a bunch of tests") {
@@ -48,11 +48,33 @@ object CompositionFilterSpec : Spek({
                     catTest,
                     horseTest
             )
-            it("should filter properly the union") {
-                filterUnion.filter(tests) shouldEqual emptyList()
+            it("should filter properly the intersection") {
+                filterIntersection.filter(tests) shouldEqual listOf(dogTest)
             }
-            it("should filterNot properly the union") {
-                filterUnion.filterNot(tests) shouldEqual listOf(dogTest, catTest, horseTest)
+            it("should filterNot properly the intersection") {
+                filterIntersection.filterNot(tests) shouldEqual listOf(catTest, horseTest)
+            }
+        }
+    }
+
+    given("a CompositionFilter with different Filters and Subtract Operation") {
+        val filterIntersection = CompositionFilter(
+                listOf(
+                        SimpleClassnameFilter(".*Dog.*".toRegex()),
+                        AnnotationFilter("com.example.BestAnimal".toRegex())),
+                CompositionFilter.OPERATION.SUBTRACT)
+
+        on("a bunch of tests") {
+            val tests = listOf(
+                    dogTest,
+                    catTest,
+                    horseTest
+            )
+            it("should filter properly the subtract") {
+                filterIntersection.filter(tests) shouldEqual listOf(catTest, horseTest)
+            }
+            it("should filterNot properly the subtract") {
+                filterIntersection.filterNot(tests) shouldEqual listOf(dogTest)
             }
         }
     }
@@ -60,5 +82,5 @@ object CompositionFilterSpec : Spek({
 
 })
 
-private fun stubTest(className: String,
-                     vararg annotations: String) = Test("com.example", className, "fakeMethod", listOf(*annotations))
+private fun stubTest(className: String, vararg annotations: String) = Test("com.example", className, "fakeMethod",
+        listOf(*annotations))

--- a/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/MarathonTest.kt
+++ b/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/MarathonTest.kt
@@ -1,0 +1,2 @@
+package com.malinskiy.marathon.android
+

--- a/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/MarathonTest.kt
+++ b/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/MarathonTest.kt
@@ -1,2 +1,0 @@
-package com.malinskiy.marathon.android
-


### PR DESCRIPTION
Implementation of `CompositionFilter` 

We need to support different composition of filters in our builds. With CompositionFilter we can compose thorough different Operators on filters already defined by Marathon. 

Operations supported:

- Union
- Intersection 
- Subtract

Example 

``` 
     CompositionFilter( listOf(
                         SimpleClassnameFilter(".*Dog.*".toRegex()),
                         AnnotationFilter("com.example.BestAnimal".toRegex())),
                         CompositionFilter.OPERATION.INTERSECTION)

```

Will return for filter "Dog" and Horse/Cat for not filtering on the intersection operation for the given values:

``` 
    val dogTest = stubTest(class = "FilterAnimalDogTest", annotation="com.example.BestAnimal")
    val catTest = stubTest(class = "FilterAnimalCatTest", annotation="")
    val horseTest = stubTest(class = "FilterAnimalHorseTest", annotation="")

