### PR TITLE
[vendor-android] Add support for instrumentation arguments

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -6,13 +6,14 @@ import com.malinskiy.marathon.android.defaultInitTimeoutMillis
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import java.io.File
 
-data class FileAndroidConfiguration(@JsonProperty("androidSdk") val androidSdk: File?,
-                                    @JsonProperty("applicationApk") val applicationOutput: File?,
-                                    @JsonProperty("testApplicationApk") val testApplicationOutput: File,
-                                    @JsonProperty("autoGrantPermission") val autoGrantPermission: Boolean?,
-                                    @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?)
+data class FileAndroidConfiguration(
+        @JsonProperty("androidSdk") val androidSdk: File?,
+        @JsonProperty("applicationApk") val applicationOutput: File?,
+        @JsonProperty("testApplicationApk") val testApplicationOutput: File,
+        @JsonProperty("autoGrantPermission") val autoGrantPermission: Boolean?,
+        @JsonProperty("instrumentationArgs") val instrumentationArgs: Map<String, String>?,
+        @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?)
     : FileVendorConfiguration {
-
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
         val finalAndroidSdk = androidSdk
@@ -24,6 +25,7 @@ data class FileAndroidConfiguration(@JsonProperty("androidSdk") val androidSdk: 
                 applicationOutput = applicationOutput,
                 testApplicationOutput = testApplicationOutput,
                 autoGrantPermission = autoGrantPermission ?: false,
+                instrumentationArgs = instrumentationArgs ?: emptyMap(),
                 adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis
         )
     }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
@@ -16,6 +16,7 @@ object FileAndroidConfigurationSpek : Spek({
                     null,
                     File.createTempFile("foo", "bar"),
                     null,
+                    null,
                     null
             )
         }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -136,6 +136,7 @@ object ConfigFactorySpec : Spek({
                         File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),
                         File("kotlin-buildscript/build/outputs/apk/androidTest/debug/kotlin-buildscript-debug-androidTest.apk"),
                         true,
+                        mapOf("debug" to "false"),
                         30_000
                 )
             }
@@ -176,6 +177,7 @@ object ConfigFactorySpec : Spek({
                         File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),
                         File("kotlin-buildscript/build/outputs/apk/androidTest/debug/kotlin-buildscript-debug-androidTest.apk"),
                         false,
+                        mapOf(),
                         30_000
                 )
             }
@@ -236,6 +238,7 @@ object ConfigFactorySpec : Spek({
                         File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),
                         File("kotlin-buildscript/build/outputs/apk/androidTest/debug/kotlin-buildscript-debug-androidTest.apk"),
                         false,
+                        mapOf(),
                         30_000
                 )
             }

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -66,3 +66,5 @@ vendorConfiguration:
   applicationApk: "kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"
   testApplicationApk: "kotlin-buildscript/build/outputs/apk/androidTest/debug/kotlin-buildscript-debug-androidTest.apk"
   autoGrantPermission: true
+  instrumentationArgs:
+    debug: "false"

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
@@ -94,7 +94,6 @@ class PoolProgressTracker {
     }
 
     fun progress(): Float {
-        println("Completed $completed out of $totalTests, $failed tests failed")
         return (completed.toFloat() + failed.toFloat()) / totalTests.toFloat()
     }
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -34,6 +34,7 @@ open class MarathonExtension(project: Project) {
 
     //Android specific for now
     var autoGrantPermission: Boolean? = null
+    var instrumentationArgs: MutableMap<String, String> = mutableMapOf()
 
     //Kotlin way
     fun analytics(block: AnalyticsConfig.() -> Unit) {
@@ -66,6 +67,10 @@ open class MarathonExtension(project: Project) {
 
     fun filteringConfiguration(block: FilteringPluginConfiguration.() -> Unit) {
         filteringConfiguration = FilteringPluginConfiguration().also(block)
+    }
+
+    fun instrumentationArgs(block: MutableMap<String, String>.() -> Unit) {
+        instrumentationArgs = mutableMapOf<String, String>().also(block)
     }
 
     //Groovy way
@@ -114,6 +119,12 @@ open class MarathonExtension(project: Project) {
     fun filteringConfiguration(closure: Closure<*>) {
         filteringConfiguration = FilteringPluginConfiguration()
         closure.delegate = filteringConfiguration
+        closure.call()
+    }
+
+    fun instrumentationArgs(closure: Closure<*>) {
+        instrumentationArgs = mutableMapOf()
+        closure.delegate = instrumentationArgs
         closure.call()
     }
 }

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -35,11 +35,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
 
         val baseOutputDir = if (extensionConfig.baseOutputDir != null) File(extensionConfig.baseOutputDir) else File(project.buildDir, "reports/marathon")
         val output = File(baseOutputDir, flavorName)
-        val autoGrantPermission = extensionConfig.autoGrantPermission
-        val vendorConfiguration = when (autoGrantPermission) {
-            null -> AndroidConfiguration(sdk, applicationApk, instrumentationApk)
-            else -> AndroidConfiguration(sdk, applicationApk, instrumentationApk, autoGrantPermission)
-        }
+
+        val vendorConfiguration = createAndroidConfiguration(extensionConfig, applicationApk, instrumentationApk)
 
         cnf = Configuration(
                 extensionConfig.name,
@@ -79,6 +76,19 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         if (!success && !cnf.ignoreFailures) {
             throw GradleException("Tests failed! See ${cnf.outputDir}/html/index.html")
         }
+    }
+
+    private fun createAndroidConfiguration(extension: MarathonExtension,
+                                           applicationApk: File?,
+                                           instrumentationApk: File): AndroidConfiguration {
+        val autoGrantPermission = extension.autoGrantPermission ?: false
+        val instrumentationArgs = extension.instrumentationArgs
+
+        return AndroidConfiguration(sdk,
+                applicationApk,
+                instrumentationApk,
+                autoGrantPermission,
+                instrumentationArgs)
     }
 
     override fun getIgnoreFailures(): Boolean = ignoreFailure

--- a/sample/android-app/Marathonfile
+++ b/sample/android-app/Marathonfile
@@ -9,3 +9,5 @@ vendorConfiguration:
   applicationApk: "app/build/outputs/apk/debug/app-debug.apk"
   testApplicationApk: "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
   autoGrantPermission: true
+  instrumentationArgs:
+    debug: "false"

--- a/sample/android-app/app/build.gradle.kts
+++ b/sample/android-app/app/build.gradle.kts
@@ -28,6 +28,12 @@ android {
     }
 }
 
+marathon {
+    instrumentationArgs {
+        put("debug", "false")
+    }
+}
+
 dependencies {
     implementation(Libraries.appCompat)
     implementation(Libraries.constraintLayout)

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -12,6 +12,7 @@ data class AndroidConfiguration(val androidSdk: File,
                                 val applicationOutput: File?,
                                 val testApplicationOutput: File,
                                 val autoGrantPermission: Boolean = false,
+                                val instrumentationArgs: Map<String, String> = emptyMap(),
                                 val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis) : VendorConfiguration {
 
     override fun testParser(): TestParser? {


### PR DESCRIPTION
Fixes #175

Use it in Marathonfile as following:

```yaml
instrumentationArgs:
  debug: "false" 
```

and in gradle plugin it's exposed as MutableMap:
```kotlin
marathon {
    instrumentationArgs {
        put("debug", "false")
    }
}
```