### PR TITLE
Feature/Add preferable recorder type config

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -3,6 +3,7 @@ package com.malinskiy.marathon.cli.args
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.defaultInitTimeoutMillis
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import java.io.File
 
@@ -14,7 +15,8 @@ data class FileAndroidConfiguration(
         @JsonProperty("instrumentationArgs") val instrumentationArgs: Map<String, String>?,
         @JsonProperty("applicationPmClear") val applicationPmClear: Boolean?,
         @JsonProperty("testApplicationPmClear") val testApplicationPmClear: Boolean?,
-        @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?)
+        @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?,
+        @JsonProperty("preferableRecorderType") val preferableRecorderType: DeviceFeature? = null)
     : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -23,14 +25,15 @@ data class FileAndroidConfiguration(
                 ?: throw ConfigurationException("No android SDK path specified")
 
         return AndroidConfiguration(
-                androidSdk = finalAndroidSdk,
-                applicationOutput = applicationOutput,
-                testApplicationOutput = testApplicationOutput,
-                autoGrantPermission = autoGrantPermission ?: false,
-                instrumentationArgs = instrumentationArgs ?: emptyMap(),
-                applicationPmClear = applicationPmClear ?: false,
-                testApplicationPmClear = testApplicationPmClear ?: false,
-                adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis
+            androidSdk = finalAndroidSdk,
+            applicationOutput = applicationOutput,
+            testApplicationOutput = testApplicationOutput,
+            autoGrantPermission = autoGrantPermission ?: false,
+            instrumentationArgs = instrumentationArgs ?: emptyMap(),
+            applicationPmClear = applicationPmClear ?: false,
+            testApplicationPmClear = testApplicationPmClear ?: false,
+            adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis,
+            preferableRecorderType = preferableRecorderType
         )
     }
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -9,6 +9,7 @@ import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import com.malinskiy.marathon.execution.AnalyticsConfiguration
 import com.malinskiy.marathon.execution.AnnotationFilter
@@ -139,7 +140,8 @@ object ConfigFactorySpec : Spek({
                         mapOf("debug" to "false"),
                         true,
                         true,
-                        30_000
+                        30_000,
+                        DeviceFeature.SCREENSHOT
                 )
             }
         }

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -70,3 +70,4 @@ vendorConfiguration:
   testApplicationPmClear: true
   instrumentationArgs:
     debug: "false"
+  preferableRecorderType: "screenshot"

--- a/core/src/main/kotlin/com/malinskiy/marathon/device/DeviceFeature.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/device/DeviceFeature.kt
@@ -1,6 +1,18 @@
 package com.malinskiy.marathon.device
 
+import com.fasterxml.jackson.annotation.JsonCreator
+
 enum class DeviceFeature {
     VIDEO,
-    SCREENSHOT
+    SCREENSHOT;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun fromString(key: String?): DeviceFeature? {
+            return key?.let {
+                DeviceFeature.valueOf(it.toUpperCase())
+            }
+        }
+    }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/vendor/VendorConfiguration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/vendor/VendorConfiguration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.vendor
 
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.log.MarathonLogConfigurator
@@ -8,4 +9,5 @@ interface VendorConfiguration {
     fun logConfigurator(): MarathonLogConfigurator?
     fun testParser(): TestParser?
     fun deviceProvider(): DeviceProvider?
+    fun preferableRecorderType(): DeviceFeature?
 }

--- a/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.analytics.metrics
 
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.AnalyticsConfiguration
 import com.malinskiy.marathon.execution.Configuration
@@ -38,6 +39,7 @@ class MetricsProviderFactorySpek : Spek({
                         override fun testParser(): TestParser? = null
                         override fun deviceProvider(): DeviceProvider? = null
                         override fun logConfigurator(): MarathonLogConfigurator? = null
+                        override fun preferableRecorderType(): DeviceFeature? = null
                     },
                     analyticsTracking = false
             )

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
@@ -1,6 +1,7 @@
 package com.malinskiy.marathon.report
 
 import com.google.gson.Gson
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.AnalyticsConfiguration
@@ -45,6 +46,7 @@ class SummaryCompilerTest : Spek({
                 override fun testParser(): TestParser? = null
                 override fun deviceProvider(): DeviceProvider? = null
                 override fun logConfigurator(): MarathonLogConfigurator? = null
+                override fun preferableRecorderType(): DeviceFeature? = null
             },
             analyticsTracking = false)
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon
 
+import com.malinskiy.marathon.device.DeviceFeature
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -32,6 +33,8 @@ open class MarathonExtension(project: Project) {
 
     var applicationPmClear: Boolean? = null
     var testApplicationPmClear: Boolean? = null
+
+    var preferableRecorderType: DeviceFeature? = null
 
     var analyticsTracking: Boolean = false
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -87,6 +87,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val instrumentationArgs = extension.instrumentationArgs
         val applicationPmClear = extension.applicationPmClear ?: DEFAULT_APPLICATION_PM_CLEAR
         val testApplicationPmClear = extension.testApplicationPmClear ?: DEFAULT_APPLICATION_PM_CLEAR
+        val preferableRecorderType = extension.preferableRecorderType
 
         return AndroidConfiguration(sdk,
                 applicationApk,
@@ -94,7 +95,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
                 autoGrantPermission,
                 instrumentationArgs,
                 applicationPmClear,
-                testApplicationPmClear)
+                testApplicationPmClear,
+                preferableRecorderType = preferableRecorderType)
     }
 
     override fun getIgnoreFailures(): Boolean = ignoreFailure

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.android
 
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.log.MarathonLogConfigurator
@@ -19,7 +20,8 @@ data class AndroidConfiguration(val androidSdk: File,
                                 val instrumentationArgs: Map<String, String> = emptyMap(),
                                 val applicationPmClear: Boolean = DEFAULT_APPLICATION_PM_CLEAR,
                                 val testApplicationPmClear: Boolean = DEFAULT_TEST_APPLICATION_PM_CLEAR,
-                                val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis) : VendorConfiguration {
+                                val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis,
+                                val preferableRecorderType: DeviceFeature? = null) : VendorConfiguration {
 
     override fun testParser(): TestParser? {
         return AndroidTestParser()
@@ -30,4 +32,6 @@ data class AndroidConfiguration(val androidSdk: File,
     }
 
     override fun logConfigurator(): MarathonLogConfigurator? = null
+
+    override fun preferableRecorderType(): DeviceFeature? = preferableRecorderType
 }

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSConfiguration.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSConfiguration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.ios
 
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.log.MarathonLogConfigurator
@@ -25,5 +26,7 @@ data class IOSConfiguration(val derivedDataDir: File,
     override fun deviceProvider(): DeviceProvider? = IOSDeviceProvider()
 
     override fun logConfigurator(): MarathonLogConfigurator? = IOSLogConfigurator()
+
+    override fun preferableRecorderType(): DeviceFeature? = null
 }
 

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/TestVendorConfiguration.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/TestVendorConfiguration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.test
 
+import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.vendor.VendorConfiguration
 
@@ -7,4 +8,5 @@ class TestVendorConfiguration(var testParser: TestParser, var deviceProvider: St
     override fun testParser() = testParser
     override fun deviceProvider() = deviceProvider
     override fun logConfigurator() = null
+    override fun preferableRecorderType(): DeviceFeature? = null
 }


### PR DESCRIPTION
Currently, if a device allows capturing both videos and gifs, marathon always chooses video. If it fails to capture video, there is no way to request gifs records. With this config, we can select how we would like to capture test progress.

Any feedback is welcome :)