### PR TITLE
Add install options configuration

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.cli.args
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.android.AndroidConfiguration
+import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
 import com.malinskiy.marathon.android.defaultInitTimeoutMillis
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import java.io.File
@@ -14,7 +15,8 @@ data class FileAndroidConfiguration(
         @JsonProperty("instrumentationArgs") val instrumentationArgs: Map<String, String>?,
         @JsonProperty("applicationPmClear") val applicationPmClear: Boolean?,
         @JsonProperty("testApplicationPmClear") val testApplicationPmClear: Boolean?,
-        @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?)
+        @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?,
+        @JsonProperty("installOptions") val installOptions: String?)
     : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -30,7 +32,8 @@ data class FileAndroidConfiguration(
                 instrumentationArgs = instrumentationArgs ?: emptyMap(),
                 applicationPmClear = applicationPmClear ?: false,
                 testApplicationPmClear = testApplicationPmClear ?: false,
-                adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis
+                adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis,
+                installOptions = installOptions ?: DEFAULT_INSTALL_OPTIONS
         )
     }
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
@@ -19,6 +19,7 @@ object FileAndroidConfigurationSpek : Spek({
                     null,
                     null,
                     null,
+                    null,
                     null
             )
         }
@@ -68,6 +69,14 @@ object FileAndroidConfigurationSpek : Spek({
             it("should be equal") {
                 val timeout = 500_000
                 configuration.copy(adbInitTimeoutMillis = timeout).toAndroidConfiguration(env).adbInitTimeoutMillis shouldEqual timeout
+            }
+        }
+        group("install options") {
+            it("should be empty string by default") {
+                configuration.toAndroidConfiguration(env).installOptions shouldEqual ""
+            }
+            it("should be equal if provided") {
+                configuration.copy(installOptions = "-d").toAndroidConfiguration(env).installOptions shouldEqual "-d"
             }
         }
     }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -139,7 +139,8 @@ object ConfigFactorySpec : Spek({
                         mapOf("debug" to "false"),
                         true,
                         true,
-                        30_000
+                        30_000,
+                        "-d"
                 )
             }
         }
@@ -182,7 +183,8 @@ object ConfigFactorySpec : Spek({
                         mapOf(),
                         false,
                         false,
-                        30_000
+                        30_000,
+                        ""
                 )
             }
         }
@@ -245,7 +247,8 @@ object ConfigFactorySpec : Spek({
                         mapOf(),
                         false,
                         false,
-                        30_000
+                        30_000,
+                        ""
                 )
             }
         }

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -70,3 +70,4 @@ vendorConfiguration:
   testApplicationPmClear: true
   instrumentationArgs:
     debug: "false"
+  installOptions: "-d"

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -32,6 +32,8 @@ open class MarathonExtension(project: Project) {
 
     var applicationPmClear: Boolean? = null
     var testApplicationPmClear: Boolean? = null
+    var adbInitTimeout: Int? = null
+    var installOptions: String? = null
 
     var analyticsTracking: Boolean = false
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -5,6 +5,8 @@ import com.android.build.gradle.api.TestVariant
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.DEFAULT_APPLICATION_PM_CLEAR
 import com.malinskiy.marathon.android.DEFAULT_AUTO_GRANT_PERMISSION
+import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
+import com.malinskiy.marathon.android.defaultInitTimeoutMillis
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.extensions.extractApplication
 import com.malinskiy.marathon.extensions.extractTestApplication
@@ -87,6 +89,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val instrumentationArgs = extension.instrumentationArgs
         val applicationPmClear = extension.applicationPmClear ?: DEFAULT_APPLICATION_PM_CLEAR
         val testApplicationPmClear = extension.testApplicationPmClear ?: DEFAULT_APPLICATION_PM_CLEAR
+        val adbInitTimeout = extension.adbInitTimeout ?: defaultInitTimeoutMillis
+        val installOptions = extension.installOptions ?: DEFAULT_INSTALL_OPTIONS
 
         return AndroidConfiguration(sdk,
                 applicationApk,
@@ -94,7 +98,9 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
                 autoGrantPermission,
                 instrumentationArgs,
                 applicationPmClear,
-                testApplicationPmClear)
+                testApplicationPmClear,
+                adbInitTimeout,
+                installOptions)
     }
 
     override fun getIgnoreFailures(): Boolean = ignoreFailure

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -11,6 +11,7 @@ const val defaultInitTimeoutMillis = 30_000
 const val DEFAULT_AUTO_GRANT_PERMISSION = false
 const val DEFAULT_APPLICATION_PM_CLEAR = false
 const val DEFAULT_TEST_APPLICATION_PM_CLEAR = false
+const val DEFAULT_INSTALL_OPTIONS = ""
 
 data class AndroidConfiguration(val androidSdk: File,
                                 val applicationOutput: File?,
@@ -19,7 +20,8 @@ data class AndroidConfiguration(val androidSdk: File,
                                 val instrumentationArgs: Map<String, String> = emptyMap(),
                                 val applicationPmClear: Boolean = DEFAULT_APPLICATION_PM_CLEAR,
                                 val testApplicationPmClear: Boolean = DEFAULT_TEST_APPLICATION_PM_CLEAR,
-                                val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis) : VendorConfiguration {
+                                val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis,
+                                val installOptions: String = DEFAULT_INSTALL_OPTIONS) : VendorConfiguration {
 
     override fun testParser(): TestParser? {
         return AndroidTestParser()

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/AndroidAppInstaller.kt
@@ -64,10 +64,16 @@ class AndroidAppInstaller(configuration: Configuration) {
     }
 
     private fun optionalParams(device: IDevice): String {
-        return if (device.version.apiLevel >= MARSHMALLOW_VERSION_CODE && androidConfiguration.autoGrantPermission) {
+        val options = if (device.version.apiLevel >= MARSHMALLOW_VERSION_CODE && androidConfiguration.autoGrantPermission) {
             "-g -r"
         } else {
             "-r"
+        }
+
+        return if (androidConfiguration.installOptions.isNotEmpty()) {
+            "$options ${androidConfiguration.installOptions}"
+        } else {
+            options
         }
     }
 }


### PR DESCRIPTION
`-r` flag doesn't allow to force install the apk in case of `INSTALL_FAILED_VERSION_DOWNGRADE` error, it is necessary to pass `-d` param for this. Therefore I've added optional installOptions param.