### PR TITLE
Increase max video duration from 60 to 180 sec

### DIFF
--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorder.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorder.kt
@@ -33,7 +33,7 @@ internal class ScreenRecorder(private val device: IDevice,
 
     companion object {
         private val logger = MarathonLogging.logger("ScreenRecorder")
-        private const val DURATION = 60
+        private const val DURATION = 180
         private const val BITRATE_MB_PER_SECOND = 1
         private val options = ScreenRecorderOptions.Builder()
                 .setTimeLimit(DURATION.toLong(), SECONDS)


### PR DESCRIPTION
180 sec is limit of `screenrecord` on android