### PR TITLE
gradle plugin should mark output folder as gradle task output

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -33,7 +33,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
     var ignoreFailure: Boolean = false
 
     @OutputDirectory
-    lateinit var output: File
+    var fakeLockingOutput = File(project.rootProject.buildDir, "fake-marathon-locking-output")
 
     @TaskAction
     fun runMarathon() {
@@ -41,7 +41,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val applicationApk = applicationVariant.extractApplication()
 
         val baseOutputDir = if (extensionConfig.baseOutputDir != null) File(extensionConfig.baseOutputDir) else File(project.buildDir, "reports/marathon")
-        output = File(baseOutputDir, flavorName)
+        val output = File(baseOutputDir, flavorName)
 
         val vendorConfiguration = createAndroidConfiguration(extensionConfig, applicationApk, instrumentationApk)
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -16,6 +16,7 @@ import com.malinskiy.marathon.usageanalytics.UsageAnalytics
 import com.malinskiy.marathon.usageanalytics.tracker.Event
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
 import java.io.File
@@ -31,6 +32,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
     lateinit var cnf: Configuration
     var ignoreFailure: Boolean = false
 
+    @OutputDirectory
+    lateinit var output: File
 
     @TaskAction
     fun runMarathon() {
@@ -38,7 +41,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val applicationApk = applicationVariant.extractApplication()
 
         val baseOutputDir = if (extensionConfig.baseOutputDir != null) File(extensionConfig.baseOutputDir) else File(project.buildDir, "reports/marathon")
-        val output = File(baseOutputDir, flavorName)
+        output = File(baseOutputDir, flavorName)
 
         val vendorConfiguration = createAndroidConfiguration(extensionConfig, applicationApk, instrumentationApk)
 


### PR DESCRIPTION
to prevent multiple executions of the task at the same time

Fixes #198 

FYI @lukaville 