### PR TITLE
AndroidDeviceTestRunner now checks if test contains the @Ignore

### DIFF
--- a/sample/android-app/app/src/androidTest/java/com/example/ClassIgnoredTest.kt
+++ b/sample/android-app/app/src/androidTest/java/com/example/ClassIgnoredTest.kt
@@ -1,0 +1,25 @@
+package com.example
+
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import org.junit.Assert.fail
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@Ignore
+class ClassIgnoredTest {
+
+    @Rule
+    @JvmField
+    val rule = ActivityTestRule(MainActivity::class.java)
+
+    val screen = MainScreen()
+
+    @Test
+    fun testAlwaysIgnored() {
+        fail("Should've been ignored because of @Ignore on a class")
+    }
+}


### PR DESCRIPTION
AndroidDeviceTestRunner filters the @Ignore test classes out now without sending them to the device

One edge-case is when the batch consists of only ignored tests, in this
case Android's test runner will output exception but it doesn't break
anything in the marathon

Fixes #186 