### PR TITLE
Basic @Parameterized support for Android

### DIFF
--- a/sample/android-app/app/src/androidTest/java/com/example/ExampleInstrumentedTest.kt
+++ b/sample/android-app/app/src/androidTest/java/com/example/ExampleInstrumentedTest.kt
@@ -1,0 +1,42 @@
+package com.example
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.util.Arrays
+
+import org.junit.Assert.assertEquals
+
+@RunWith(Parameterized::class)
+class ExampleInstrumentedTest(private val input: Int, private val expected: Int) {
+
+    @Test
+    fun test() {
+        assertEquals(expected.toLong(), compute(input).toLong())
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> {
+            return Arrays.asList(
+                    arrayOf<Any>(0, 0),
+                    arrayOf<Any>(1, 1),
+                    arrayOf<Any>(2, 1),
+                    arrayOf<Any>(3, 2),
+                    arrayOf<Any>(4, 3),
+                    arrayOf<Any>(5, 5),
+                    arrayOf<Any>(6, 8)
+            )
+        }
+
+        fun compute(n: Int): Int {
+            return if (n <= 1) {
+                n
+            } else {
+                compute(n - 1) + compute(n - 2)
+            }
+        }
+    }
+}

--- a/sample/android-app/app/src/androidTest/java/com/example/ParameterizedTest.kt
+++ b/sample/android-app/app/src/androidTest/java/com/example/ParameterizedTest.kt
@@ -9,7 +9,7 @@ import java.util.Arrays
 import org.junit.Assert.assertEquals
 
 @RunWith(Parameterized::class)
-class ExampleInstrumentedTest(private val input: Int, private val expected: Int) {
+class ParameterizedTest(private val input: Int, private val expected: Int) {
 
     @Test
     fun test() {

--- a/sample/android-app/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/android-app/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
AndroidDeviceTestRunner now checks if the results are coming from a parameterised test

If they are then it will collapse all the results following the logic:
- Test is passed only if all the sub-tests are passed
- Test is failed if at least one of the tests is failed
- Test is randomly INCOMPLETE/ASSUMPTION_FAILURE/IGNORE if it contains
  any mix of these and any amount of passed

Unfortunately there is no way to properly propagate these results
upstream to the generic runner. Reporting on these should probably be
done after refactoring the reporting logic

Fixes #189