### PR TITLE
Add support for configurable serial provider for Android

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
 import com.malinskiy.marathon.android.defaultInitTimeoutMillis
+import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import java.io.File
@@ -18,7 +19,8 @@ data class FileAndroidConfiguration(
         @JsonProperty("testApplicationPmClear") val testApplicationPmClear: Boolean?,
         @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?,
         @JsonProperty("installOptions") val installOptions: String?,
-        @JsonProperty("preferableRecorderType") val preferableRecorderType: DeviceFeature? = null)
+        @JsonProperty("preferableRecorderType") val preferableRecorderType: DeviceFeature?,
+        @JsonProperty("serialStrategy") val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC)
     : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -27,16 +29,17 @@ data class FileAndroidConfiguration(
                 ?: throw ConfigurationException("No android SDK path specified")
 
         return AndroidConfiguration(
-            androidSdk = finalAndroidSdk,
-            applicationOutput = applicationOutput,
-            testApplicationOutput = testApplicationOutput,
-            autoGrantPermission = autoGrantPermission ?: false,
-            instrumentationArgs = instrumentationArgs ?: emptyMap(),
-            applicationPmClear = applicationPmClear ?: false,
-            testApplicationPmClear = testApplicationPmClear ?: false,
-            adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis,
-            installOptions = installOptions ?: DEFAULT_INSTALL_OPTIONS,
-            preferableRecorderType = preferableRecorderType
+                androidSdk = finalAndroidSdk,
+                applicationOutput = applicationOutput,
+                testApplicationOutput = testApplicationOutput,
+                autoGrantPermission = autoGrantPermission ?: false,
+                instrumentationArgs = instrumentationArgs ?: emptyMap(),
+                applicationPmClear = applicationPmClear ?: false,
+                testApplicationPmClear = testApplicationPmClear ?: false,
+                adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis,
+                installOptions = installOptions ?: DEFAULT_INSTALL_OPTIONS,
+                preferableRecorderType = preferableRecorderType,
+                serialStrategy = serialStrategy
         )
     }
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.cli.args
 
+import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldThrow
@@ -20,7 +21,9 @@ object FileAndroidConfigurationSpek : Spek({
                     null,
                     null,
                     null,
-                    null
+                    null,
+                    null,
+                    SerialStrategy.AUTOMATIC
             )
         }
 

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.malinskiy.marathon.android.AndroidConfiguration
+import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
@@ -142,7 +143,8 @@ object ConfigFactorySpec : Spek({
                         true,
                         30_000,
                         "-d",
-                        DeviceFeature.SCREENSHOT
+                        DeviceFeature.SCREENSHOT,
+                        SerialStrategy.AUTOMATIC
                 )
             }
         }
@@ -186,7 +188,9 @@ object ConfigFactorySpec : Spek({
                         false,
                         false,
                         30_000,
-                        ""
+                        "",
+                        null,
+                        SerialStrategy.AUTOMATIC
                 )
             }
         }
@@ -250,7 +254,9 @@ object ConfigFactorySpec : Spek({
                         false,
                         false,
                         30_000,
-                        ""
+                        "",
+                        null,
+                        SerialStrategy.HOSTNAME
                 )
             }
         }

--- a/cli/src/test/resources/fixture/config/sample_6.yaml
+++ b/cli/src/test/resources/fixture/config/sample_6.yaml
@@ -4,3 +4,4 @@ vendorConfiguration:
   type: "Android"
   applicationApk: "kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"
   testApplicationApk: "kotlin-buildscript/build/outputs/apk/androidTest/debug/kotlin-buildscript-debug-androidTest.apk"
+  serialStrategy: "hostname"

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.android
 
+import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.device.DeviceFeature
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.TestParser
@@ -23,7 +24,8 @@ data class AndroidConfiguration(val androidSdk: File,
                                 val testApplicationPmClear: Boolean = DEFAULT_TEST_APPLICATION_PM_CLEAR,
                                 val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis,
                                 val installOptions: String = DEFAULT_INSTALL_OPTIONS,
-                                val preferableRecorderType: DeviceFeature? = null) : VendorConfiguration {
+                                val preferableRecorderType: DeviceFeature? = null,
+                                val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC) : VendorConfiguration {
 
     override fun testParser(): TestParser? {
         return AndroidTestParser()

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/exception/InvalidSerialConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/exception/InvalidSerialConfiguration.kt
@@ -1,0 +1,6 @@
+package com.malinskiy.marathon.android.exception
+
+import com.malinskiy.marathon.android.serial.SerialStrategy
+
+class InvalidSerialConfiguration(serialStrategy: SerialStrategy):
+        RuntimeException("Serial configuration was set to $serialStrategy, could not find expected serial")

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/serial/SerialStrategy.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/serial/SerialStrategy.kt
@@ -1,0 +1,21 @@
+package com.malinskiy.marathon.android.serial
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+enum class SerialStrategy {
+    AUTOMATIC,
+    MARATHON_PROPERTY,
+    BOOT_PROPERTY,
+    HOSTNAME,
+    DDMS;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun fromString(key: String?): SerialStrategy? {
+            return key?.let {
+                valueOf(it.toUpperCase())
+            }
+        }
+    }
+}


### PR DESCRIPTION
serialStrategy field now accepts user-defined android serial source which should support multiple emulators with the same real serial but different DDMS serial like `emulator-5554` and `emulator-5556` by specifying `ddms` option.

Available options:
- automatic
- marathon_property
- boot_property
- hostname
- ddms

Fixes #223 

Need to update the docs via separate PR