### PR TITLE
Add uncompleted tests retry quota

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -27,6 +27,7 @@ data class FileConfiguration(
         var isCodeCoverageEnabled: Boolean?,
         var fallbackToScreenshots: Boolean?,
         var strictMode: Boolean?,
+        var uncompletedTestRetryQuota: Int?,
 
         var testClassRegexes: Collection<Regex>?,
         var includeSerialRegexes: Collection<Regex>?,

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -51,6 +51,7 @@ class ConfigFactory(val mapper: ObjectMapper) {
                 config.isCodeCoverageEnabled,
                 config.fallbackToScreenshots,
                 config.strictMode,
+                config.uncompletedTestRetryQuota,
                 config.testClassRegexes,
                 config.includeSerialRegexes,
                 config.excludeSerialRegexes,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -35,6 +35,7 @@ data class Configuration constructor(
         val isCodeCoverageEnabled: Boolean,
         val fallbackToScreenshots: Boolean,
         val strictMode: Boolean,
+        val uncompletedTestRetryQuota: Int,
 
         val testClassRegexes: Collection<Regex>,
         val includeSerialRegexes: Collection<Regex>,
@@ -64,6 +65,7 @@ data class Configuration constructor(
                 isCodeCoverageEnabled: Boolean?,
                 fallbackToScreenshots: Boolean?,
                 strictMode: Boolean?,
+                uncompletedTestRetryQuota: Int?,
 
                 testClassRegexes: Collection<Regex>?,
                 includeSerialRegexes: Collection<Regex>?,
@@ -91,6 +93,7 @@ data class Configuration constructor(
                     isCodeCoverageEnabled = isCodeCoverageEnabled ?: false,
                     fallbackToScreenshots = fallbackToScreenshots ?: false,
                     strictMode = strictMode ?: false,
+                    uncompletedTestRetryQuota = uncompletedTestRetryQuota ?: Integer.MAX_VALUE,
                     testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test$")),
                     includeSerialRegexes = includeSerialRegexes ?: emptyList(),
                     excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
@@ -1,9 +1,8 @@
 package com.malinskiy.marathon.execution
 
 import com.malinskiy.marathon.device.Device
-import com.malinskiy.marathon.test.Test
 
 data class TestBatchResults(val device: Device,
                             val finished: Collection<TestResult>,
                             val failed: Collection<TestResult>,
-                            val uncompleted: Collection<Test>)
+                            val uncompleted: Collection<TestResult>)

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -70,7 +70,6 @@ class QueueActor(private val configuration: Configuration,
 
     private suspend fun onBatchCompleted(device: DeviceInfo, results: TestBatchResults) {
         val (failedUncompletedTests, uncompleted) = results.uncompleted.partition {
-            println(uncompletedTestsRetryCount[it.test])
             (uncompletedTestsRetryCount[it.test] ?: 0) >= configuration.uncompletedTestRetryQuota
         }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -69,12 +69,12 @@ class QueueActor(private val configuration: Configuration,
     }
 
     private suspend fun onBatchCompleted(device: DeviceInfo, results: TestBatchResults) {
-        val (failedUncompletedTests, uncompleted) = results.uncompleted.partition {
+        val (uncompletedRetryQuotaExceeded, uncompleted) = results.uncompleted.partition {
             (uncompletedTestsRetryCount[it.test] ?: 0) >= configuration.uncompletedTestRetryQuota
         }
 
         val finished = results.finished
-        val failed = results.failed + failedUncompletedTests
+        val failed = results.failed + uncompletedRetryQuotaExceeded
 
         logger.debug { "handle test results ${device.serialNumber}" }
         if (finished.isNotEmpty()) {

--- a/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
@@ -30,6 +30,7 @@ class MetricsProviderFactorySpek : Spek({
                     isCodeCoverageEnabled = null,
                     fallbackToScreenshots = null,
                     strictMode = null,
+                    uncompletedTestRetryQuota = null,
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
@@ -1,0 +1,257 @@
+package com.malinskiy.marathon.execution.queue
+
+import com.malinskiy.marathon.analytics.Analytics
+import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.device.DeviceStub
+import com.malinskiy.marathon.device.toDeviceInfo
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.execution.DevicePoolMessage.FromQueue
+import com.malinskiy.marathon.execution.DevicePoolMessage.FromQueue.ExecuteBatch
+import com.malinskiy.marathon.execution.TestBatchResults
+import com.malinskiy.marathon.execution.TestResult
+import com.malinskiy.marathon.execution.TestShard
+import com.malinskiy.marathon.execution.TestStatus
+import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
+import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.TestVendorConfiguration
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldContainSame
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import java.io.File
+
+class QueueActorSpek : Spek({
+    describe("queue actor") {
+        val job by memoized { Job() }
+        val poolChannel by memoized { Channel<FromQueue>() }
+        val analytics by memoized { mock<Analytics>() }
+
+        given("uncompleted tests retry quota is 0, max batch size is 1 and one test in the shard") {
+            val actor by memoized {
+                createQueueActor(
+                        configuration = DEFAULT_CONFIGURATION.copy(
+                                uncompletedTestRetryQuota = 0,
+                                batchingStrategy = FixedSizeBatchingStrategy(size = 1)
+                        ),
+                        tests = listOf(TEST_1),
+                        poolChannel = poolChannel,
+                        analytics = analytics,
+                        job = job
+                )
+            }
+
+            describe("requesting batch and handling completed batch") {
+                beforeEachTest {
+                    runBlocking {
+                        actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
+                        poolChannel.receive()
+                    }
+                }
+
+                describe("received uncompleted test once") {
+                    beforeEachTest {
+                        val results = createBatchResult(uncompleted = listOf(
+                                createTestResult(TEST_1, TestStatus.FAILURE)
+                        ))
+                        runBlocking {
+                            actor.send(QueueMessage.Completed(TEST_DEVICE_INFO, results))
+                        }
+                    }
+
+                    it("should have empty queue") {
+                        val isEmptyDeferred = CompletableDeferred<Boolean>()
+                        runBlocking {
+                            actor.send(QueueMessage.IsEmpty(isEmptyDeferred))
+                            isEmptyDeferred.await() shouldBe true
+                        }
+                    }
+
+                    it("should report test as failed") {
+                        runBlocking {
+                            val captor = argumentCaptor<TestResult>()
+                            verify(analytics).trackTestFinished(any(), any(), captor.capture())
+                            captor.firstValue.test shouldBe TEST_1
+                            captor.firstValue.status shouldBe TestStatus.FAILURE
+                        }
+                    }
+                }
+            }
+        }
+
+        given("uncompleted tests retry quota is 1, max batch size is 1 and one test in the shard") {
+            val actor by memoized {
+                createQueueActor(
+                        configuration = DEFAULT_CONFIGURATION.copy(
+                                uncompletedTestRetryQuota = 1,
+                                batchingStrategy = FixedSizeBatchingStrategy(size = 1)
+                        ),
+                        tests = listOf(TEST_1),
+                        poolChannel = poolChannel,
+                        analytics = analytics,
+                        job = job
+                )
+            }
+
+            describe("requesting batch and handling completed batch") {
+                beforeEachTest {
+                    runBlocking {
+                        actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
+                        poolChannel.receive()
+                    }
+                }
+
+                describe("received uncompleted test first time") {
+                    beforeEachTest {
+                        val results = createBatchResult(uncompleted = listOf(
+                                createTestResult(TEST_1, TestStatus.FAILURE)
+                        ))
+                        runBlocking {
+                            actor.send(QueueMessage.Completed(TEST_DEVICE_INFO, results))
+                        }
+                    }
+
+                    it("should have not empty queue") {
+                        val isEmptyDeferred = CompletableDeferred<Boolean>()
+                        runBlocking {
+                            actor.send(QueueMessage.IsEmpty(isEmptyDeferred))
+                            isEmptyDeferred.await() shouldBe false
+                        }
+                    }
+
+                    it("should not report any test finishes") {
+                        runBlocking {
+                            verify(analytics, never()).trackTestFinished(any(), any(), any())
+                        }
+                    }
+
+                    it("should provide uncompleted test in the batch") {
+                        runBlocking {
+                            actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
+                            val response = poolChannel.receive()
+                            response::class shouldBe ExecuteBatch::class
+                            (response as ExecuteBatch).batch.tests shouldContainSame listOf(TEST_1)
+                        }
+                    }
+
+                    describe("received uncompleted test second time") {
+                        beforeEachTest {
+                            runBlocking {
+                                actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
+                                poolChannel.receive()
+                            }
+
+                            val results = createBatchResult(uncompleted = listOf(
+                                    createTestResult(TEST_1, TestStatus.FAILURE)
+                            ))
+                            runBlocking {
+                                actor.send(QueueMessage.Completed(TEST_DEVICE_INFO, results))
+                            }
+                        }
+
+                        it("should have empty queue") {
+                            val isEmptyDeferred = CompletableDeferred<Boolean>()
+                            runBlocking {
+                                actor.send(QueueMessage.IsEmpty(isEmptyDeferred))
+                                isEmptyDeferred.await() shouldBe true
+                            }
+                        }
+
+                        it("should report test as failed") {
+                            runBlocking {
+                                val captor = argumentCaptor<TestResult>()
+                                verify(analytics).trackTestFinished(any(), any(), captor.capture())
+                                captor.firstValue.test shouldBe TEST_1
+                                captor.firstValue.status shouldBe TestStatus.FAILURE
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        afterEachTest {
+            job.cancel()
+        }
+    }
+})
+
+private val TEST_DEVICE = DeviceStub()
+private val TEST_DEVICE_INFO = TEST_DEVICE.toDeviceInfo()
+
+private val TEST_1 = Test("", "", "test1", emptyList())
+
+private fun createBatchResult(finished: List<TestResult> = emptyList(),
+                              failed: List<TestResult> = emptyList(),
+                              uncompleted: List<TestResult> = emptyList()): TestBatchResults = TestBatchResults(
+        TEST_DEVICE,
+        finished,
+        failed,
+        uncompleted
+)
+
+private fun createTestResult(test: Test, status: TestStatus) = TestResult(
+        test = test,
+        device = TEST_DEVICE_INFO,
+        status = status,
+        startTime = 0,
+        endTime = 0,
+        stacktrace = null,
+        attachments = emptyList()
+)
+
+private fun createQueueActor(configuration: Configuration,
+                             tests: List<Test>,
+                             poolChannel: SendChannel<FromQueue>,
+                             analytics: Analytics,
+                             job: Job) = QueueActor(
+        configuration,
+        TestShard(tests, emptyList()),
+        analytics,
+        poolChannel,
+        DevicePoolId("test"),
+        mock(),
+        job,
+        Dispatchers.Unconfined
+)
+
+private val DEFAULT_CONFIGURATION = Configuration(
+        name = "",
+        outputDir = File(""),
+        analyticsConfiguration = null,
+        poolingStrategy = null,
+        shardingStrategy = null,
+        sortingStrategy = null,
+        batchingStrategy = null,
+        flakinessStrategy = null,
+        retryStrategy = null,
+        filteringConfiguration = null,
+        ignoreFailures = null,
+        isCodeCoverageEnabled = null,
+        fallbackToScreenshots = null,
+        strictMode = null,
+        uncompletedTestRetryQuota = null,
+        testClassRegexes = null,
+        includeSerialRegexes = null,
+        excludeSerialRegexes = null,
+        testBatchTimeoutMillis = null,
+        testOutputTimeoutMillis = null,
+        debug = null,
+        vendorConfiguration = TestVendorConfiguration(
+                testParser = mock(),
+                deviceProvider = mock()
+        ),
+        analyticsTracking = false
+)

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -37,6 +37,7 @@ object TestResultReporterSpec : Spek({
             isCodeCoverageEnabled = null,
             fallbackToScreenshots = null,
             strictMode = null,
+            uncompletedTestRetryQuota = null,
             testClassRegexes = null,
             includeSerialRegexes = null,
             excludeSerialRegexes = null,

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
@@ -37,6 +37,7 @@ class SummaryCompilerTest : Spek({
             isCodeCoverageEnabled = null,
             fallbackToScreenshots = null,
             strictMode = null,
+            uncompletedTestRetryQuota = null,
             testClassRegexes = null,
             includeSerialRegexes = null,
             excludeSerialRegexes = null,

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -23,6 +23,7 @@ open class MarathonExtension(project: Project) {
     var isCodeCoverageEnabled: Boolean? = null
     var fallbackToScreenshots: Boolean? = null
     var strictMode: Boolean? = null
+    var uncompletedTestRetryQuota: Int? = null
 
     var testClassRegexes: Collection<String>? = null
     var includeSerialRegexes: Collection<String>? = null

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -60,6 +60,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
                 extensionConfig.isCodeCoverageEnabled,
                 extensionConfig.fallbackToScreenshots,
                 extensionConfig.strictMode,
+                extensionConfig.uncompletedTestRetryQuota,
                 extensionConfig.testClassRegexes?.map { it.toRegex() },
                 extensionConfig.includeSerialRegexes?.map { it.toRegex() },
                 extensionConfig.excludeSerialRegexes?.map { it.toRegex() },

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
@@ -28,6 +28,7 @@ import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.attachment.AttachmentProvider
 import com.malinskiy.marathon.report.logs.LogWriter
 import com.malinskiy.marathon.test.TestBatch
+import com.malinskiy.marathon.time.SystemTimer
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
@@ -161,11 +162,13 @@ class AndroidDevice(val ddmsDevice: IDevice,
         val logCatListener = LogCatListener(this, devicePoolId, LogWriter(fileManager))
                 .also { attachmentProviders.add(it) }
 
+        val timer = SystemTimer()
+
         return CompositeTestRunListener(
                 listOf(
                         recorderListener,
                         logCatListener,
-                        TestRunResultsListener(testBatch, this, deferred, attachmentProviders),
+                        TestRunResultsListener(testBatch, this, deferred, timer, attachmentProviders),
                         DebugTestRunListener(this),
                         ProgressTestRunListener(this, devicePoolId, progressReporter)
                 )

--- a/vendor/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
+++ b/vendor/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
@@ -44,6 +44,7 @@ class AndroidDeviceTestRunnerSpek : Spek({
                     isCodeCoverageEnabled = null,
                     fallbackToScreenshots = null,
                     strictMode = null,
+                    uncompletedTestRetryQuota = null,
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,

--- a/vendor/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
+++ b/vendor/vendor-android/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
@@ -30,6 +30,7 @@ class AndroidTestParserSpek : Spek({
                     isCodeCoverageEnabled = null,
                     fallbackToScreenshots = null,
                     strictMode = null,
+                    uncompletedTestRetryQuota = null,
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/IOSDeviceLogParser.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/IOSDeviceLogParser.kt
@@ -25,6 +25,7 @@ class IOSDeviceLogParser(device: Device,
     private val diagnosticLogsPathFinder: DiagnosticLogsPathFinder
     private val sessionResultsPathFinder: SessionResultsPathFinder
     init {
+        val timer = SystemTimer()
         testLogListener = TestLogListener()
         diagnosticLogsPathFinder = DiagnosticLogsPathFinder()
         sessionResultsPathFinder = SessionResultsPathFinder()
@@ -37,7 +38,7 @@ class IOSDeviceLogParser(device: Device,
                 diagnosticLogsPathFinder,
                 sessionResultsPathFinder,
                 TestRunProgressParser(
-                    SystemTimer(),
+                    timer,
                     packageNameFormatter,
                     listOf(
                         ProgressReportingListener(
@@ -46,7 +47,8 @@ class IOSDeviceLogParser(device: Device,
                             testBatch = testBatch,
                             deferredResults = deferredResults,
                             progressReporter = progressReporter,
-                            testLogListener = testLogListener
+                            testLogListener = testLogListener,
+                            timer = timer
                         ),
                         testLogListener
                     )

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
@@ -10,6 +10,7 @@ import com.malinskiy.marathon.execution.progress.ProgressReporter
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import com.malinskiy.marathon.test.toSafeTestName
+import com.malinskiy.marathon.time.Timer
 import kotlinx.coroutines.CompletableDeferred
 
 class ProgressReportingListener(private val device: Device,
@@ -17,19 +18,35 @@ class ProgressReportingListener(private val device: Device,
                                 private val testBatch: TestBatch,
                                 private val deferredResults: CompletableDeferred<TestBatchResults>,
                                 private val progressReporter: ProgressReporter,
-                                private val testLogListener: TestLogListener): TestRunListener {
+                                private val testLogListener: TestLogListener,
+                                private val timer: Timer) : TestRunListener {
 
     private val success: MutableList<TestResult> = mutableListOf()
     private val failure: MutableList<TestResult> = mutableListOf()
 
     override fun batchFinished() {
-        val received = (success + failure).map { it.test.toSafeTestName() }.toHashSet()
+        val received = (success + failure)
+        val receivedTestNames = received.map { it.test.toSafeTestName() }.toHashSet()
 
-        val incompleteTests = testBatch.tests.filter {
-            !received.contains(it.toSafeTestName())
+        val uncompleted = testBatch.tests.filter {
+            !receivedTestNames.contains(it.toSafeTestName())
+        }.createUncompletedTestResults(received)
+
+        deferredResults.complete(TestBatchResults(device, success, failure, uncompleted))
+    }
+
+    private fun List<Test>.createUncompletedTestResults(received: Collection<TestResult>): Collection<TestResult> {
+        val lastCompletedTestEndTime = received.maxBy { it.endTime }?.endTime ?: timer.currentTimeMillis()
+        return map {
+            TestResult(
+                    it,
+                    device.toDeviceInfo(),
+                    TestStatus.FAILURE,
+                    lastCompletedTestEndTime,
+                    lastCompletedTestEndTime,
+                    testLogListener.getLastLog()
+            )
         }
-
-        deferredResults.complete(TestBatchResults(device, success, failure, incompleteTests))
     }
 
     override fun testFailed(test: Test, startTime: Long, endTime: Long) {

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
@@ -69,6 +69,7 @@ object DerivedDataManagerSpek: Spek({
                     isCodeCoverageEnabled = null,
                     fallbackToScreenshots = null,
                     strictMode = null,
+                    uncompletedTestRetryQuota = null,
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
@@ -31,6 +31,7 @@ object IOSTestParserSpek : Spek({
                     isCodeCoverageEnabled = null,
                     fallbackToScreenshots = null,
                     strictMode = null,
+                    uncompletedTestRetryQuota = null,
                     testClassRegexes = null,
                     includeSerialRegexes = null,
                     excludeSerialRegexes = null,

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
@@ -25,6 +25,7 @@ class ConfigurationFactory {
     var excludeSerialRegexes = null
     var fallbackToScreenshots = null
     var strictMode = null
+    var uncompletedTestRetryQuota = null
     var filteringConfiguration = null
     var flakinessStrategy: FlakinessStrategy? = null
     var ignoreFailures = null
@@ -64,6 +65,7 @@ class ConfigurationFactory {
                     isCodeCoverageEnabled,
                     fallbackToScreenshots,
                     strictMode,
+                    uncompletedTestRetryQuota,
                     testClassRegexes,
                     includeSerialRegexes,
                     excludeSerialRegexes,


### PR DESCRIPTION
Fixes #243 by `uncompletedTestRetryQuota` configuration option. By default, it has the same behavior as now (infinitely re-runs uncompleted tests)