### PR TITLE
ddmlib timeout and other improvements

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     val kotlin = "1.3.31"
     val coroutines = "1.2.1"
 
-    val ddmlib = "26.3.0"
+    val ddmlib = "26.5.0-rc02"
     val dexTestParser = "2.1.1"
     val kotlinLogging = "1.4.9"
     val slf4jAPI = "1.0.0"

--- a/core/src/main/kotlin/com/malinskiy/marathon/actor/StateMachine.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/actor/StateMachine.kt
@@ -58,8 +58,8 @@ class StateMachine<STATE : Any, EVENT : Any, SIDE_EFFECT : Any> private construc
                     notifyOnEnter(event)
                 }
             }
+            transition.notifyOnTransition()
         }
-        transition.notifyOnTransition()
         return transition
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/AnalyticsFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/AnalyticsFactory.kt
@@ -6,16 +6,16 @@ import com.malinskiy.marathon.analytics.tracker.TrackerFactory
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.report.internal.DeviceInfoReporter
-import com.malinskiy.marathon.report.internal.TestResultReporter
+import com.malinskiy.marathon.report.internal.TestResultRepo
 
 class AnalyticsFactory(configuration: Configuration,
                        fileManager: FileManager,
                        deviceInfoReporter: DeviceInfoReporter,
-                       testResultReporter: TestResultReporter,
+                       testResultRepo: TestResultRepo,
                        gson: Gson) {
 
     private val metricsFactory = MetricsProviderFactory(configuration)
-    private val trackerFactory = TrackerFactory(configuration, fileManager, deviceInfoReporter, testResultReporter,
+    private val trackerFactory = TrackerFactory(configuration, fileManager, deviceInfoReporter, testResultRepo,
             gson)
 
     fun create(): Analytics = Analytics(trackerFactory.create(), metricsFactory.create())

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/TrackerFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/TrackerFactory.kt
@@ -12,14 +12,14 @@ import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.report.allure.AllureTestListener
 import com.malinskiy.marathon.report.internal.DeviceInfoReporter
-import com.malinskiy.marathon.report.internal.TestResultReporter
+import com.malinskiy.marathon.report.internal.TestResultRepo
 import com.malinskiy.marathon.report.junit.JUnitReporter
 import java.io.File
 
 internal class TrackerFactory(private val configuration: Configuration,
                               private val fileManager: FileManager,
                               private val deviceInfoReporter: DeviceInfoReporter,
-                              private val testResultReporter: TestResultReporter,
+                              private val testResultRepo: TestResultRepo,
                               private val gson: Gson) {
 
     val rawTestResultTracker = RawTestResultTracker(fileManager, gson)
@@ -29,7 +29,7 @@ internal class TrackerFactory(private val configuration: Configuration,
         val defaultTrackers = listOf(
                 JUnitTracker(JUnitReporter(fileManager)),
                 DeviceTracker(deviceInfoReporter),
-                TestResultsTracker(testResultReporter),
+                TestResultsTracker(testResultRepo),
                 rawTestResultTracker,
                 allureTracker
         )

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/local/TestResultsTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/tracker/local/TestResultsTracker.kt
@@ -4,11 +4,11 @@ import com.malinskiy.marathon.analytics.tracker.NoOpTracker
 import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.execution.TestResult
-import com.malinskiy.marathon.report.internal.TestResultReporter
+import com.malinskiy.marathon.report.internal.TestResultRepo
 
-internal class TestResultsTracker(private val testResultReporter: TestResultReporter) : NoOpTracker() {
+internal class TestResultsTracker(private val testResultRepo: TestResultRepo) : NoOpTracker() {
 
     override fun trackTestFinished(poolId: DevicePoolId, device: DeviceInfo, testResult: TestResult) {
-        testResultReporter.testFinished(poolId, device, testResult)
+        testResultRepo.testFinished(poolId, device, testResult)
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/device/Device.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/device/Device.kt
@@ -19,12 +19,11 @@ interface Device {
     suspend fun execute(configuration: Configuration,
                 devicePoolId: DevicePoolId,
                 testBatch: TestBatch,
-                deferred: CompletableDeferred<TestBatchResults>,
                 progressReporter: ProgressReporter)
 
     suspend fun prepare(configuration: Configuration)
 
-    fun forceEnd()
+    fun getResults(): TestBatchResults
 
     fun dispose()
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/device/Device.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/device/Device.kt
@@ -23,6 +23,9 @@ interface Device {
                 progressReporter: ProgressReporter)
 
     suspend fun prepare(configuration: Configuration)
+
+    fun forceEnd()
+
     fun dispose()
 }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/exceptions/DeviceTimeoutException.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/exceptions/DeviceTimeoutException.kt
@@ -1,0 +1,9 @@
+package com.malinskiy.marathon.exceptions
+
+/**
+ * Indicates that device get stuck: timeout exceeded but ddmlib didn't stop run
+ */
+class DeviceTimeoutException: RuntimeException {
+    constructor(cause: Throwable): super(cause)
+    constructor(message: String): super(message)
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/CompositionFilter.kt
@@ -54,6 +54,9 @@ class CompositionFilter(@SerializedName("filters") private val filters: List<Tes
 
     override fun hashCode(): Int = filters.hashCode() + op.hashCode()
 
+    override fun toString(): String =
+            "${this.javaClass.simpleName}(op=$op,filters=$filters)"
+
     enum class OPERATION {
         UNION,
         INTERSECTION,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -88,7 +88,7 @@ data class Configuration constructor(
                     batchingStrategy = batchingStrategy ?: IsolateBatchingStrategy(),
                     flakinessStrategy = flakinessStrategy ?: IgnoreFlakinessStrategy(),
                     retryStrategy = retryStrategy ?: NoRetryStrategy(),
-                    filteringConfiguration = filteringConfiguration ?: FilteringConfiguration(emptyList(), emptyList()),
+                    filteringConfiguration = filteringConfiguration ?: FilteringConfiguration(emptyList(), emptyList(), emptyList()),
                     ignoreFailures = ignoreFailures ?: false,
                     isCodeCoverageEnabled = isCodeCoverageEnabled ?: false,
                     fallbackToScreenshots = fallbackToScreenshots ?: false,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -37,7 +37,7 @@ class DevicePoolActor(private val poolId: DevicePoolId,
             is DevicePoolMessage.FromScheduler.Terminate -> terminate()
             is DevicePoolMessage.FromDevice.IsReady -> deviceReady(msg)
             is DevicePoolMessage.FromDevice.CompletedTestBatch -> deviceCompleted(msg.device, msg.results)
-            is DevicePoolMessage.FromDevice.ReturnTestBatch -> deviceReturnedTestBatch(msg.device, msg.batch)
+//            is DevicePoolMessage.FromDevice.ReturnTestBatch -> deviceReturnedTestBatch(msg.device, msg.batch)
             is DevicePoolMessage.FromQueue.Notify -> notifyDevices()
             is DevicePoolMessage.FromQueue.Terminated -> onQueueTerminated()
             is DevicePoolMessage.FromQueue.ExecuteBatch -> executeBatch(msg.device, msg.batch)
@@ -64,10 +64,10 @@ class DevicePoolActor(private val poolId: DevicePoolId,
         terminate()
     }
 
-    private suspend fun deviceReturnedTestBatch(device: Device, batch: TestBatch) {
-        queue.send(QueueMessage.ReturnBatch(device.toDeviceInfo(), batch))
-    }
-
+//    private suspend fun deviceReturnedTestBatch(device: Device, batch: TestBatch) {
+//        queue.send(QueueMessage.ReturnBatch(device.toDeviceInfo(), batch))
+//    }
+//
     private suspend fun deviceCompleted(device: Device, results: TestBatchResults) {
         queue.send(QueueMessage.Completed(device.toDeviceInfo(), results))
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolMessage.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolMessage.kt
@@ -14,7 +14,7 @@ sealed class DevicePoolMessage {
     sealed class FromDevice(val device: Device) : DevicePoolMessage() {
         class IsReady(device: Device) : FromDevice(device)
         class CompletedTestBatch(device: Device, val results: TestBatchResults) : FromDevice(device)
-        class ReturnTestBatch(device: Device, val batch: TestBatch) : FromDevice(device)
+//        class ReturnTestBatch(device: Device, val batch: TestBatch) : FromDevice(device)
     }
 
     sealed class FromQueue : DevicePoolMessage() {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/FilteringConfiguration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/FilteringConfiguration.kt
@@ -3,4 +3,5 @@ package com.malinskiy.marathon.execution
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class FilteringConfiguration(@JsonProperty("whitelist", required = false) val whitelist: Collection<TestFilter> = emptyList(),
-                                  @JsonProperty("blacklist", required = false) val blacklist: Collection<TestFilter> = emptyList())
+                                  @JsonProperty("blacklist", required = false) val blacklist: Collection<TestFilter> = emptyList(),
+                                  @JsonProperty("ignorelist", required = false) val ignorelist: Collection<TestFilter> = emptyList())

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestBatchResults.kt
@@ -3,6 +3,7 @@ package com.malinskiy.marathon.execution
 import com.malinskiy.marathon.device.Device
 
 data class TestBatchResults(val device: Device,
-                            val finished: Collection<TestResult>,
+                            val passed: Collection<TestResult>,
                             val failed: Collection<TestResult>,
-                            val uncompleted: Collection<TestResult>)
+                            val incomplete: Collection<TestResult>,
+                            val missed: Collection<TestResult>)

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceAction.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceAction.kt
@@ -6,7 +6,14 @@ import kotlinx.coroutines.CompletableDeferred
 
 sealed class DeviceAction {
     object Initialize : DeviceAction()
-    data class Terminate(val batch: TestBatch? = null) : DeviceAction()
+    data class ReturnBatchAndInitialize(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+
+    object Terminate : DeviceAction()
+    data class StopAndTerminatee(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+
     data class ExecuteBatch(val batch: TestBatch, val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
-    data class NotifyIsReady(val result: CompletableDeferred<TestBatchResults>? = null) : DeviceAction()
+
+    data class SendResultAndNotifyIsReady(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+
+    object NotifyIsReady : DeviceAction()
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceAction.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceAction.kt
@@ -6,14 +6,15 @@ import kotlinx.coroutines.CompletableDeferred
 
 sealed class DeviceAction {
     object Initialize : DeviceAction()
-    data class ReturnBatchAndInitialize(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+    object ReturnBatchAndInitialize : DeviceAction()
 
     object Terminate : DeviceAction()
-    data class StopAndTerminatee(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
 
-    data class ExecuteBatch(val batch: TestBatch, val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+    object StopAndTerminatee : DeviceAction()
 
-    data class SendResultAndNotifyIsReady(val result: CompletableDeferred<TestBatchResults>) : DeviceAction()
+    data class ExecuteBatch(val batch: TestBatch) : DeviceAction()
+
+    object SendResultAndNotifyIsReady : DeviceAction()
 
     object NotifyIsReady : DeviceAction()
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -161,14 +161,14 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
     }
 
     private fun sendResults() {
-        launch {
+        runBlocking {
             val result = device.getResults()
             pool.send(DevicePoolMessage.FromDevice.CompletedTestBatch(device, result))
         }
     }
 
     private fun notifyIsReady() {
-        launch {
+        runBlocking {
             pool.send(IsReady(device))
         }
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -109,7 +109,7 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
                 return@onTransition
             }
 
-            logger.debug("Transition from ${it.fromState.javaClass.simpleName} to ${validTransition.toState} by event ${validTransition.event}")
+            logger.debug("Transition from ${it.fromState.javaClass.simpleName} to ${validTransition.toState} by event ${validTransition.event} with side effect ${validTransition.sideEffect}")
 
             val sideEffect = validTransition.sideEffect
             val justForWarning = when (sideEffect) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -5,6 +5,7 @@ import com.malinskiy.marathon.actor.StateMachine
 import com.malinskiy.marathon.device.Device
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.exceptions.DeviceLostException
+import com.malinskiy.marathon.exceptions.DeviceTimeoutException
 import com.malinskiy.marathon.exceptions.TestBatchExecutionException
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.DevicePoolMessage
@@ -14,14 +15,11 @@ import com.malinskiy.marathon.execution.progress.ProgressReporter
 import com.malinskiy.marathon.execution.withRetry
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.test.TestBatch
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.SendChannel
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.properties.Delegates
+import kotlin.properties.Delegates.observable
 
 class DeviceActor(private val devicePoolId: DevicePoolId,
                   private val pool: SendChannel<DevicePoolMessage>,
@@ -39,18 +37,18 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
                 transitionTo(DeviceState.Initializing, DeviceAction.Initialize)
             }
             on<DeviceEvent.Terminate> {
-                transitionTo(DeviceState.Terminated, DeviceAction.Terminate())
+                transitionTo(DeviceState.Terminated, DeviceAction.Terminate)
             }
             on<DeviceEvent.WakeUp> {
                 dontTransition()
             }
         }
         state<DeviceState.Initializing> {
-            on<DeviceEvent.Complete> {
-                transitionTo(DeviceState.Ready, DeviceAction.NotifyIsReady())
+            on<DeviceEvent.InitializingComplete> {
+                transitionTo(DeviceState.Ready, DeviceAction.NotifyIsReady)
             }
             on<DeviceEvent.Terminate> {
-                transitionTo(DeviceState.Terminated, DeviceAction.Terminate())
+                transitionTo(DeviceState.Terminated, DeviceAction.Terminate)
             }
             on<DeviceEvent.WakeUp> {
                 dontTransition()
@@ -62,59 +60,73 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
                 transitionTo(DeviceState.Running(it.batch, deferred), DeviceAction.ExecuteBatch(it.batch, deferred))
             }
             on<DeviceEvent.WakeUp> {
-                transitionTo(DeviceState.Ready, DeviceAction.NotifyIsReady())
+                transitionTo(DeviceState.Ready, DeviceAction.NotifyIsReady)
             }
             on<DeviceEvent.Terminate> {
-                transitionTo(DeviceState.Terminated, DeviceAction.Terminate())
+                transitionTo(DeviceState.Terminated, DeviceAction.Terminate)
             }
         }
         state<DeviceState.Running> {
             on<DeviceEvent.Terminate> {
-                transitionTo(DeviceState.Terminated, DeviceAction.Terminate(testBatch))
+                transitionTo(DeviceState.Terminated, DeviceAction.StopAndTerminatee(this.result))
             }
-            on<DeviceEvent.Complete> {
-                transitionTo(DeviceState.Ready, DeviceAction.NotifyIsReady(this.result))
+            on<DeviceEvent.RunningComplete> {
+                transitionTo(DeviceState.Ready, DeviceAction.SendResultAndNotifyIsReady(this.result))
             }
             on<DeviceEvent.WakeUp> {
                 dontTransition()
             }
+            on<DeviceEvent.Initialize> {
+                transitionTo(DeviceState.Initializing, DeviceAction.ReturnBatchAndInitialize(this.result))
+            }
         }
         state<DeviceState.Terminated> {
-            on<DeviceEvent.Complete> {
+            on<DeviceEvent.WakeUp> {
                 dontTransition()
             }
         }
         onTransition {
             val validTransition = it as? StateMachine.Transition.Valid
             if (validTransition !is StateMachine.Transition.Valid) {
-                if (it.event !is DeviceEvent.WakeUp) {
-                    logger.error { "Invalid transition from ${it.fromState} event ${it.event}" }
-                }
+                logger.error { "Invalid transition from ${it.fromState} by event ${it.event}" }
                 return@onTransition
             }
+
+            logger.debug("Transition from ${it.fromState.javaClass.simpleName} to ${validTransition.toState} by event ${validTransition.event}")
+
             val sideEffect = validTransition.sideEffect
-            when (sideEffect) {
+            val justForWarning = when (sideEffect) {
+                null -> {
+                    // вам должно быть стыдно!
+                }
                 DeviceAction.Initialize -> {
                     initialize()
                 }
+                is DeviceAction.SendResultAndNotifyIsReady -> {
+                    sendResults(sideEffect.result)
+                    notifyIsReady()
+                }
                 is DeviceAction.NotifyIsReady -> {
-                    sideEffect.result?.let {
-                        sendResults(it)
-                    }
                     notifyIsReady()
                 }
                 is DeviceAction.ExecuteBatch -> {
                     executeBatch(sideEffect.batch, sideEffect.result)
                 }
                 is DeviceAction.Terminate -> {
-                    val batch = sideEffect.batch
-                    if (batch == null) {
-                        terminate()
-                    } else {
-                        returnBatch(batch).invokeOnCompletion {
-                            terminate()
-                        }
-                    }
+                    device.forceEnd()
+                    terminate()
+                }
+                is DeviceAction.StopAndTerminatee -> {
+                    device.forceEnd()
+                    sendResults(sideEffect.result)
+                    terminate()
+                }
+                is DeviceAction.ReturnBatchAndInitialize -> {
+                    device.forceEnd()
+                    sendResults(sideEffect.result)
+                    initialize()
+
+//                    terminate()
                 }
             }
         }
@@ -150,11 +162,13 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
         }
     }
 
-    private var job by Delegates.observable<Job?>(null) { _, _, newValue ->
+    private var job by observable<Job?>(null) { _, _, newValue ->
         newValue?.invokeOnCompletion {
-            if (it == null) {
-                state.transition(DeviceEvent.Complete)
-            } else {
+            if (newValue.isCancelled) {
+                logger.debug("seems like terminating is in progress.")
+
+            } else if (it != null) {
+                // job is alive but failed
                 logger.error(it) { "Error ${it.message}" }
                 state.transition(DeviceEvent.Terminate)
                 terminate()
@@ -176,9 +190,14 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
                         }
                     }
                 }
+
+                state.transition(DeviceEvent.InitializingComplete)
+
             } catch (e: Exception) {
+                logger.error(e) { "Critical error during device initialisation" }
                 state.transition(DeviceEvent.Terminate)
             }
+
         }
     }
 
@@ -186,19 +205,24 @@ class DeviceActor(private val devicePoolId: DevicePoolId,
         logger.debug { "executeBatch ${device.serialNumber}" }
         job = async {
             try {
+                logger.debug("batch started")
                 device.execute(configuration, devicePoolId, batch, result, progressReporter)
+                logger.debug("batch finished")
+
+                state.transition(DeviceEvent.RunningComplete)
+
             } catch (e: DeviceLostException) {
                 logger.error(e) { "Critical error during execution" }
                 state.transition(DeviceEvent.Terminate)
-            } catch (e: TestBatchExecutionException) {
-                returnBatch(batch)
-            }
-        }
-    }
 
-    private fun returnBatch(batch: TestBatch): Job {
-        return launch {
-            pool.send(DevicePoolMessage.FromDevice.ReturnTestBatch(device, batch))
+            } catch (e: DeviceTimeoutException) {
+                logger.error(e) { "Critical error during execution" }
+                state.transition(DeviceEvent.Initialize) // there is the difference with DeviceLostException: we still have device so we can kick it
+
+            } catch (e: TestBatchExecutionException) {
+                logger.error(e) { "Critical error during execution" }
+                state.transition(DeviceEvent.RunningComplete)
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
@@ -5,7 +5,8 @@ import kotlinx.coroutines.CompletableDeferred
 
 sealed class DeviceEvent {
     data class Execute(val batch: TestBatch) : DeviceEvent()
-    object Complete : DeviceEvent()
+    object InitializingComplete : DeviceEvent()
+    object RunningComplete : DeviceEvent()
     object Initialize : DeviceEvent()
     object Terminate : DeviceEvent()
     object WakeUp : DeviceEvent()

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
@@ -1,6 +1,5 @@
 package com.malinskiy.marathon.execution.device
 
-import com.malinskiy.marathon.execution.TestBatchResults
 import com.malinskiy.marathon.test.TestBatch
 import kotlinx.coroutines.CompletableDeferred
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceEvent.kt
@@ -1,12 +1,13 @@
 package com.malinskiy.marathon.execution.device
 
+import com.malinskiy.marathon.execution.TestBatchResults
 import com.malinskiy.marathon.test.TestBatch
 import kotlinx.coroutines.CompletableDeferred
 
 sealed class DeviceEvent {
     data class Execute(val batch: TestBatch) : DeviceEvent()
     object InitializingComplete : DeviceEvent()
-    object RunningComplete : DeviceEvent()
+    object  RunningComplete : DeviceEvent()
     object Initialize : DeviceEvent()
     object Terminate : DeviceEvent()
     object WakeUp : DeviceEvent()

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceState.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceState.kt
@@ -1,15 +1,12 @@
 package com.malinskiy.marathon.execution.device
 
-import com.malinskiy.marathon.execution.TestBatchResults
 import com.malinskiy.marathon.test.TestBatch
-import kotlinx.coroutines.CompletableDeferred
 
 sealed class DeviceState {
     object Connected : DeviceState()
     object Ready : DeviceState()
     object Initializing : DeviceState()
-    data class Running(val testBatch: TestBatch,
-                       val result: CompletableDeferred<TestBatchResults>) : DeviceState()
+    data class Running(val testBatch: TestBatch) : DeviceState()
     object Terminated : DeviceState()
 
     override fun toString(): String = "DeviceState.${this::class.java.simpleName}"

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestEvent.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestEvent.kt
@@ -7,6 +7,9 @@ sealed class TestEvent {
     data class Failed(val device: DeviceInfo,
                       val testResult: TestResult) : TestEvent()
 
+    data class Incomplete(val device: DeviceInfo,
+                          val testResult: TestResult) : TestEvent()
+
     data class Passed(val device: DeviceInfo,
                       val testResult: TestResult) : TestEvent()
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporter.kt
@@ -24,9 +24,9 @@ class TestResultReporter(private val poolId: DevicePoolId,
     private fun createState(initialCount: Int) = StateMachine.create<TestState, TestEvent, TestAction> {
         initialState(TestState.Added(initialCount))
         state<TestState.Added> {
-            on<TestEvent.Incomplete> {
-                    dontTransition(TestAction.SaveReport(it.device, it.testResult))
-            }
+//            on<TestEvent.Incomplete> {
+//                    dontTransition(TestAction.SaveReport(it.device, it.testResult))
+//            }
             on<TestEvent.Passed> {
                 if (!configuration.strictMode || count <= 1) {
                     transitionTo(TestState.Passed(it.device, it.testResult), TestAction.SaveReport(it.device, it.testResult))
@@ -46,9 +46,9 @@ class TestResultReporter(private val poolId: DevicePoolId,
             }
         }
         state<TestState.Executed> {
-            on<TestEvent.Incomplete> {
-                dontTransition(TestAction.SaveReport(it.device, it.testResult))
-            }
+//            on<TestEvent.Incomplete> {
+//                dontTransition(TestAction.SaveReport(it.device, it.testResult))
+//            }
             on<TestEvent.Failed> {
                 if (configuration.strictMode || count <= 1) {
                     transitionTo(TestState.Failed(it.device, it.testResult), TestAction.SaveReport(it.device, it.testResult))

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporter.kt
@@ -24,6 +24,9 @@ class TestResultReporter(private val poolId: DevicePoolId,
     private fun createState(initialCount: Int) = StateMachine.create<TestState, TestEvent, TestAction> {
         initialState(TestState.Added(initialCount))
         state<TestState.Added> {
+            on<TestEvent.Incomplete> {
+                    dontTransition(TestAction.SaveReport(it.device, it.testResult))
+            }
             on<TestEvent.Passed> {
                 if (!configuration.strictMode || count <= 1) {
                     transitionTo(TestState.Passed(it.device, it.testResult), TestAction.SaveReport(it.device, it.testResult))
@@ -43,6 +46,9 @@ class TestResultReporter(private val poolId: DevicePoolId,
             }
         }
         state<TestState.Executed> {
+            on<TestEvent.Incomplete> {
+                dontTransition(TestAction.SaveReport(it.device, it.testResult))
+            }
             on<TestEvent.Failed> {
                 if (configuration.strictMode || count <= 1) {
                     transitionTo(TestState.Failed(it.device, it.testResult), TestAction.SaveReport(it.device, it.testResult))
@@ -89,12 +95,16 @@ class TestResultReporter(private val poolId: DevicePoolId,
         }
     }
 
-    fun testFinished(device: DeviceInfo, testResult: TestResult) {
+    fun testPassed(device: DeviceInfo, testResult: TestResult) {
         tests[testResult.test.toTestName()]?.transition(TestEvent.Passed(device, testResult))
     }
 
     fun testFailed(device: DeviceInfo, testResult: TestResult) {
         tests[testResult.test.toTestName()]?.transition(TestEvent.Failed(device, testResult))
+    }
+
+    fun testIncomplete(device: DeviceInfo, testResult: TestResult) {
+        tests[testResult.test.toTestName()]?.transition(TestEvent.Incomplete(device, testResult))
     }
 
     fun retryTest(device: DeviceInfo, testResult: TestResult) {
@@ -122,12 +132,14 @@ class TestResultReporter(private val poolId: DevicePoolId,
         val event = transition.event
         val testResult: TestResult? = when (event) {
             is TestEvent.Passed -> event.testResult
+            is TestEvent.Incomplete -> event.testResult
             is TestEvent.Failed -> event.testResult
             is TestEvent.Retry -> event.testResult
             else -> null
         }
         val device: DeviceInfo? = when (event) {
             is TestEvent.Passed -> event.device
+            is TestEvent.Incomplete -> event.device
             is TestEvent.Failed -> event.device
             is TestEvent.Retry -> event.device
             else -> null

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -34,7 +34,7 @@ class FileManager(private val output: File) {
     fun getFiles(fileType: FileType, pool: DevicePoolId): Array<File> {
         val fileFilter: FileFilter = SuffixFileFilter(fileType.suffix)
         val deviceDirectory = get(output.absolutePath, fileType.dir, pool.name).toFile()
-        return deviceDirectory.listFiles(fileFilter)
+        return deviceDirectory.listFiles(fileFilter) ?: emptyArray()
     }
 
     fun getTestResultFilesForDevice(pool: DevicePoolId, serial: String): Array<File> {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/IgnoredTestsReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/IgnoredTestsReporter.kt
@@ -1,0 +1,37 @@
+package com.malinskiy.marathon.report
+
+import com.malinskiy.marathon.analytics.Analytics
+import com.malinskiy.marathon.device.DeviceInfo
+import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.device.NetworkState
+import com.malinskiy.marathon.device.OperatingSystem
+import com.malinskiy.marathon.execution.TestResult
+import com.malinskiy.marathon.execution.TestStatus
+import com.malinskiy.marathon.test.Test
+
+class IgnoredTestsReporter(val analytics: Analytics) {
+    val fakeDevicePoolId = DevicePoolId("ignored")
+
+    private val fakeDevice = DeviceInfo(operatingSystem = OperatingSystem("Fake OS"),
+            serialNumber = "virtual",
+            model = "virtual",
+            manufacturer = "virtual",
+            networkState = NetworkState.CONNECTED,
+            deviceFeatures = emptyList(),
+            healthy = true)
+
+    init {
+        analytics.trackDeviceConnected(fakeDevicePoolId, fakeDevice)
+    }
+
+    fun reportTest(test: Test) {
+        val tr = TestResult(test = test,
+                device = fakeDevice,
+                status = TestStatus.IGNORED,
+                startTime = System.currentTimeMillis(),
+                endTime = System.currentTimeMillis())
+
+        analytics.trackRawTestRun(fakeDevicePoolId, fakeDevice, tr)
+        analytics.trackTestFinished(fakeDevicePoolId, fakeDevice, tr)
+    }
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/SummaryCompiler.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/SummaryCompiler.kt
@@ -4,10 +4,10 @@ import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.report.internal.DeviceInfoReporter
-import com.malinskiy.marathon.report.internal.TestResultReporter
+import com.malinskiy.marathon.report.internal.TestResultRepo
 
 class SummaryCompiler(private val deviceInfoSerializer: DeviceInfoReporter,
-                      private val testResultSerializer: TestResultReporter,
+                      private val testResultSerializer: TestResultRepo,
                       private val configuration: Configuration) {
 
     fun compile(pools: List<DevicePoolId>): Summary {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/internal/TestResultRepo.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/internal/TestResultRepo.kt
@@ -8,8 +8,8 @@ import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
 import java.io.FileReader
 
-class TestResultReporter(private val fileManager: FileManager,
-                         private val gson: Gson) {
+class TestResultRepo(private val fileManager: FileManager,
+                     private val gson: Gson) {
 
     fun testFinished(poolId: DevicePoolId, device: DeviceInfo, testResult: TestResult) {
         val file = fileManager.createFile(FileType.TEST_RESULT, poolId, device, testResult.test)

--- a/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
@@ -18,6 +18,8 @@ data class Test(val pkg: String,
     override fun hashCode(): Int {
         return Objects.hash(pkg, clazz, method)
     }
+
+    override fun toString(): String = "Test($pkg.$clazz#$method)"
 }
 
 fun Test.toTestName(): String = "$pkg.$clazz#$method"

--- a/core/src/main/kotlin/com/malinskiy/marathon/test/TestBatch.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/test/TestBatch.kt
@@ -1,3 +1,9 @@
 package com.malinskiy.marathon.test
 
+import com.malinskiy.marathon.execution.Configuration
+import kotlin.math.min
+
 data class TestBatch(val tests: List<Test>)
+
+fun TestBatch.calculateTimeout(configuration: Configuration): Long =
+        min(configuration.testOutputTimeoutMillis * tests.size, configuration.testBatchTimeoutMillis)

--- a/core/src/test/kotlin/com/malinskiy/marathon/device/DeviceStub.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/device/DeviceStub.kt
@@ -18,5 +18,7 @@ class DeviceStub(override var operatingSystem: OperatingSystem = OperatingSystem
 
     override suspend fun prepare(configuration: Configuration) {}
 
+    override fun forceEnd() {}
+
     override fun dispose() {}
 }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
@@ -39,7 +39,7 @@ class QueueActorSpek : Spek({
         val poolChannel by memoized { Channel<FromQueue>() }
         val analytics by memoized { mock<Analytics>() }
 
-        given("uncompleted tests retry quota is 0, max batch size is 1 and one test in the shard") {
+        given("incomplete tests retry quota is 0, max batch size is 1 and one test in the shard") {
             val actor by memoized {
                 createQueueActor(
                         configuration = DEFAULT_CONFIGURATION.copy(
@@ -61,7 +61,7 @@ class QueueActorSpek : Spek({
                     }
                 }
 
-                describe("received uncompleted test once") {
+                describe("received incomplete test once") {
                     beforeEachTest {
                         val results = createBatchResult(uncompleted = listOf(
                                 createTestResult(TEST_1, TestStatus.FAILURE)
@@ -91,7 +91,7 @@ class QueueActorSpek : Spek({
             }
         }
 
-        given("uncompleted tests retry quota is 1, max batch size is 1 and one test in the shard") {
+        given("incomplete tests retry quota is 1, max batch size is 1 and one test in the shard") {
             val actor by memoized {
                 createQueueActor(
                         configuration = DEFAULT_CONFIGURATION.copy(
@@ -113,7 +113,7 @@ class QueueActorSpek : Spek({
                     }
                 }
 
-                describe("received uncompleted test first time") {
+                describe("received incomplete test first time") {
                     beforeEachTest {
                         val results = createBatchResult(uncompleted = listOf(
                                 createTestResult(TEST_1, TestStatus.FAILURE)
@@ -137,7 +137,7 @@ class QueueActorSpek : Spek({
                         }
                     }
 
-                    it("should provide uncompleted test in the batch") {
+                    it("should provide incomplete test in the batch") {
                         runBlocking {
                             actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
                             val response = poolChannel.receive()
@@ -146,7 +146,7 @@ class QueueActorSpek : Spek({
                         }
                     }
 
-                    describe("received uncompleted test second time") {
+                    describe("received incomplete test second time") {
                         beforeEachTest {
                             runBlocking {
                                 actor.send(QueueMessage.RequestBatch(TEST_DEVICE_INFO))
@@ -199,7 +199,8 @@ private fun createBatchResult(finished: List<TestResult> = emptyList(),
         TEST_DEVICE,
         finished,
         failed,
-        uncompleted
+        uncompleted,
+        emptyList()
 )
 
 private fun createTestResult(test: Test, status: TestStatus) = TestResult(

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -76,7 +76,7 @@ object TestResultReporterSpec : Spek({
                 val r2 = TestResult(test, deviceInfo, TestStatus.FAILURE, 2, 3)
                 val r3 = TestResult(test, deviceInfo, TestStatus.FAILURE, 4, 5)
 
-                filter.testFinished(deviceInfo, r1)
+                filter.testPassed(deviceInfo, r1)
                 filter.testFailed(deviceInfo, r2)
                 filter.testFailed(deviceInfo, r3)
 
@@ -100,7 +100,7 @@ object TestResultReporterSpec : Spek({
 
                 filter.testFailed(deviceInfo, r1)
                 filter.testFailed(deviceInfo, r2)
-                filter.testFinished(deviceInfo, r3)
+                filter.testPassed(deviceInfo, r3)
 
                 inOrder(analytics) {
                     verify(analytics).trackRawTestRun(poolId, deviceInfo, r1)
@@ -122,7 +122,7 @@ object TestResultReporterSpec : Spek({
                 val r2 = TestResult(test, deviceInfo, TestStatus.FAILURE, 2, 3)
                 val r3 = TestResult(test, deviceInfo, TestStatus.FAILURE, 4, 5)
 
-                filter.testFinished(deviceInfo, r1)
+                filter.testPassed(deviceInfo, r1)
                 filter.testFailed(deviceInfo, r2)
                 filter.testFailed(deviceInfo, r3)
 
@@ -145,8 +145,8 @@ object TestResultReporterSpec : Spek({
                 val r3 = TestResult(test, deviceInfo, TestStatus.PASSED, 4, 5)
 
                 filter.testFailed(deviceInfo, r1)
-                filter.testFinished(deviceInfo, r2)
-                filter.testFinished(deviceInfo, r3)
+                filter.testPassed(deviceInfo, r2)
+                filter.testPassed(deviceInfo, r3)
 
                 inOrder(analytics) {
                     verify(analytics).trackTestFinished(poolId, deviceInfo, r1)

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/SummaryCompilerTest.kt
@@ -11,7 +11,7 @@ import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.log.MarathonLogConfigurator
 import com.malinskiy.marathon.report.internal.DeviceInfoReporter
-import com.malinskiy.marathon.report.internal.TestResultReporter
+import com.malinskiy.marathon.report.internal.TestResultRepo
 import com.malinskiy.marathon.vendor.VendorConfiguration
 import org.amshove.kluent.shouldBe
 import org.jetbrains.spek.api.Spek
@@ -54,7 +54,7 @@ class SummaryCompilerTest : Spek({
 
     val fileManager = FileManager(configuration.outputDir)
     val gson = Gson()
-    val testResultReporter = TestResultReporter(fileManager, gson)
+    val testResultReporter = TestResultRepo(fileManager, gson)
     val deviceInfoReporter = DeviceInfoReporter(fileManager, gson)
     println(configuration.outputDir.absolutePath)
 

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
@@ -1,11 +1,13 @@
 package com.malinskiy.marathon.android.executor.listeners
 
 import com.android.ddmlib.testrunner.TestIdentifier
+import com.malinskiy.marathon.execution.TestBatchResults
 import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 
-abstract class AbstractTestRunResultListener : NoOpTestRunListener() {
+abstract class AbstractTestRunResultListener() : NoOpTestRunListener() {
 
-    private val runResult: DdmLibTestRunResult = DdmLibTestRunResult()
+    val runResult: DdmLibTestRunResult = DdmLibTestRunResult()
+
     private var active = true
 
     override fun testRunStarted(runName: String, testCount: Int) {
@@ -60,19 +62,9 @@ abstract class AbstractTestRunResultListener : NoOpTestRunListener() {
         synchronized(runResult) {
             if (active) {
                 runResult.testRunEnded(elapsedTime, runMetrics)
-                handleTestRunResults(runResult)
             }
         }
     }
 
-    abstract fun handleTestRunResults(runResult: DdmLibTestRunResult)
-
-    fun forceEnd() {
-        synchronized(runResult) {
-            if (active) {
-                active = false
-                handleTestRunResults(runResult)
-            }
-        }
-    }
+    abstract fun getResults(): TestBatchResults
 }

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
@@ -4,11 +4,11 @@ import com.android.ddmlib.testrunner.TestIdentifier
 import com.malinskiy.marathon.execution.TestBatchResults
 import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 
-abstract class AbstractTestRunResultListener() : NoOpTestRunListener() {
+abstract class AbstractTestRunResultListener : NoOpTestRunListener() {
 
     val runResult: DdmLibTestRunResult = DdmLibTestRunResult()
 
-    private var active = true
+    var active = true
 
     override fun testRunStarted(runName: String, testCount: Int) {
         synchronized(runResult) {

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/AbstractTestRunResultListener.kt
@@ -6,43 +6,73 @@ import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 abstract class AbstractTestRunResultListener : NoOpTestRunListener() {
 
     private val runResult: DdmLibTestRunResult = DdmLibTestRunResult()
+    private var active = true
 
     override fun testRunStarted(runName: String, testCount: Int) {
-        runResult.testRunStarted(runName, testCount)
+        synchronized(runResult) {
+            if (active) runResult.testRunStarted(runName, testCount)
+        }
     }
 
     override fun testStarted(test: TestIdentifier) {
-        runResult.testStarted(test)
+        synchronized(runResult) {
+            if (active) runResult.testStarted(test)
+        }
     }
 
     override fun testFailed(test: TestIdentifier, trace: String) {
-        runResult.testFailed(test, trace)
+        synchronized(runResult) {
+            if (active) runResult.testFailed(test, trace)
+        }
     }
 
     override fun testAssumptionFailure(test: TestIdentifier, trace: String) {
-        runResult.testAssumptionFailure(test, trace)
+        synchronized(runResult) {
+            if (active) runResult.testAssumptionFailure(test, trace)
+        }
     }
 
     override fun testIgnored(test: TestIdentifier) {
-        runResult.testIgnored(test)
+        synchronized(runResult) {
+            if (active) runResult.testIgnored(test)
+        }
     }
 
     override fun testEnded(test: TestIdentifier, testMetrics: Map<String, String>) {
-        runResult.testEnded(test, testMetrics)
+        synchronized(runResult) {
+            if (active) runResult.testEnded(test, testMetrics)
+        }
     }
 
     override fun testRunFailed(errorMessage: String) {
-        runResult.testRunFailed(errorMessage)
+        synchronized(runResult) {
+            if (active) runResult.testRunFailed(errorMessage)
+        }
     }
 
     override fun testRunStopped(elapsedTime: Long) {
-        runResult.testRunStopped(elapsedTime)
+        synchronized(runResult) {
+            if (active) runResult.testRunStopped(elapsedTime)
+        }
     }
 
     override fun testRunEnded(elapsedTime: Long, runMetrics: Map<String, String>) {
-        runResult.testRunEnded(elapsedTime, runMetrics)
-        handleTestRunResults(runResult)
+        synchronized(runResult) {
+            if (active) {
+                runResult.testRunEnded(elapsedTime, runMetrics)
+                handleTestRunResults(runResult)
+            }
+        }
     }
 
     abstract fun handleTestRunResults(runResult: DdmLibTestRunResult)
+
+    fun forceEnd() {
+        synchronized(runResult) {
+            if (active) {
+                active = false
+                handleTestRunResults(runResult)
+            }
+        }
+    }
 }

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/CompositeTestRunListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/CompositeTestRunListener.kt
@@ -4,8 +4,10 @@ import com.android.ddmlib.testrunner.ITestRunListener
 import com.android.ddmlib.testrunner.TestIdentifier
 
 class CompositeTestRunListener(private val listeners: List<ITestRunListener>) : ITestRunListener {
+    var active = true
+
     private inline fun execute(f: (ITestRunListener) -> Unit) {
-        listeners.forEach(f)
+        if (active) listeners.forEach(f)
     }
 
     override fun testRunStarted(runName: String?, testCount: Int) {
@@ -42,5 +44,9 @@ class CompositeTestRunListener(private val listeners: List<ITestRunListener>) : 
 
     override fun testRunEnded(elapsedTime: Long, runMetrics: MutableMap<String, String>?) {
         execute { it.testRunEnded(elapsedTime, runMetrics) }
+    }
+
+    fun terminate() {
+        active = false
     }
 }

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -61,6 +61,10 @@ class TestRunResultsListener(private val testBatch: TestBatch,
                 it.test.method != "null"
             }
 
+            if (device.serialNumber == "2b928809613f7ece") {
+                return TestBatchResults(device, emptySet(), nonNullTestResults, emptySet(), emptySet())
+            }
+
             val finished = nonNullTestResults.filter { results[it.test.identifier()]?.isSuccessful() ?: false }
             val realIncomplete = nonNullTestResults.filter {
                 results[it.test.identifier()]?.status == com.android.ddmlib.testrunner.TestResult.TestStatus.INCOMPLETE

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -61,10 +61,6 @@ class TestRunResultsListener(private val testBatch: TestBatch,
                 it.test.method != "null"
             }
 
-            if (device.serialNumber == "2b928809613f7ece") {
-                return TestBatchResults(device, emptySet(), nonNullTestResults, emptySet(), emptySet())
-            }
-
             val finished = nonNullTestResults.filter { results[it.test.identifier()]?.isSuccessful() ?: false }
             val realIncomplete = nonNullTestResults.filter {
                 results[it.test.identifier()]?.status == com.android.ddmlib.testrunner.TestResult.TestStatus.INCOMPLETE

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -22,7 +22,6 @@ import com.android.ddmlib.testrunner.TestRunResult as DdmLibTestRunResult
 
 class TestRunResultsListener(private val testBatch: TestBatch,
                              private val device: Device,
-                             private val deferred: CompletableDeferred<TestBatchResults>,
                              private val timer: Timer,
                              attachmentProviders: List<AttachmentProvider>)
     : AbstractTestRunResultListener(), AttachmentListener {
@@ -47,7 +46,7 @@ class TestRunResultsListener(private val testBatch: TestBatch,
         attachments[test]!!.add(attachment)
     }
 
-    override fun handleTestRunResults(runResult: DdmLibTestRunResult) {
+    override fun getResults(): TestBatchResults {
         val results = mergeParameterisedResults(runResult.testResults)
         val tests = testBatch.tests.associateBy { it.identifier() }
 
@@ -90,7 +89,7 @@ class TestRunResultsListener(private val testBatch: TestBatch,
             logger.debug { "failed = ${it}" }
         }
 
-        deferred.complete(TestBatchResults(device, finished, failed, realIncompleteCorrected, missed))
+        return TestBatchResults(device, finished, failed, realIncompleteCorrected, missed)
     }
 
     private fun Collection<Test>.createUncompletedTestResults(testRunResult: com.android.ddmlib.testrunner.TestRunResult,

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDevice.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDevice.kt
@@ -49,6 +49,10 @@ class IOSDevice(val simulator: RemoteSimulator,
                 val gson: Gson,
                 private val healthChangeListener: HealthChangeListener): Device, CoroutineScope {
 
+    override fun forceEnd() {
+        TODO("not implemented")
+    }
+
     val udid = simulator.udid
     val connectionId = "$udid@${simulator.host}-$connectionAttempt"
     private val deviceContext = newFixedThreadPoolContext(1, connectionId)

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDevice.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDevice.kt
@@ -49,8 +49,8 @@ class IOSDevice(val simulator: RemoteSimulator,
                 val gson: Gson,
                 private val healthChangeListener: HealthChangeListener): Device, CoroutineScope {
 
-    override fun forceEnd() {
-        TODO("not implemented")
+    override fun getResults(): TestBatchResults {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
     val udid = simulator.udid
@@ -132,7 +132,6 @@ class IOSDevice(val simulator: RemoteSimulator,
     override suspend fun execute(configuration: Configuration,
                                  devicePoolId: DevicePoolId,
                                  testBatch: TestBatch,
-                                 deferred: CompletableDeferred<TestBatchResults>,
                                  progressReporter: ProgressReporter) = withContext(coroutineContext + CoroutineName("execute")) {
         val iosConfiguration = configuration.vendorConfiguration as IOSConfiguration
         val fileManager = FileManager(configuration.outputDir)
@@ -165,8 +164,7 @@ class IOSDevice(val simulator: RemoteSimulator,
             this@IOSDevice,
             packageNameFormatter,
             devicePoolId,
-            testBatch,
-            deferred,
+            testBatch, CompletableDeferred<TestBatchResults>(), // TODO
             progressReporter,
             iosConfiguration.hideRunnerOutput
         )

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
@@ -32,7 +32,7 @@ class ProgressReportingListener(private val device: Device,
             !receivedTestNames.contains(it.toSafeTestName())
         }.createUncompletedTestResults(received)
 
-        deferredResults.complete(TestBatchResults(device, success, failure, uncompleted))
+        deferredResults.complete(TestBatchResults(device, success, failure, uncompleted, emptyList()))
     }
 
     private fun List<Test>.createUncompletedTestResults(received: Collection<TestResult>): Collection<TestResult> {

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/StubDevice.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/StubDevice.kt
@@ -25,6 +25,9 @@ class StubDevice(private val prepareTimeMillis: Long = 5000L,
                  override val abi: String = "test",
                  override val serialNumber: String = "serial-1",
                  override val healthy: Boolean = true) : Device {
+    override fun forceEnd() {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
 
     val logger = MarathonLogging.logger(StubDevice::class.java.simpleName)
 
@@ -48,6 +51,7 @@ class StubDevice(private val prepareTimeMillis: Long = 5000L,
                 TestBatchResults(this,
                         results.filter { it.isSuccess },
                         results.filter { !it.isSuccess },
+                        emptySet(),
                         emptySet()
                 )
         )


### PR DESCRIPTION
It's draft of PR. Just to review and discuss. 

Before criticizing, keep in mind that this code is in production, and these changes were vital for the operation of the new hardware.

_Changes:_

1. Implemented timeout of a ddmlib call on our side. Ddmlib itself has timeout (see `runner.setMaxTimeToOutputResponse(..)` in the `AndroidDeviceTestRunner`), but sometimes it doesn't work. 

Also I fixed a calculation of the timeout. 

2. As result we have two kind of incomplete tests: real incomplete, which started, buy not finished because timeout, and missed, which was'nt started. Result classes was extended to store all these types separately.

3. Created 'ignoreList' option to config. Ignored tests will be reported in html reports as well as in JUint's xml files, as result all ignored tests are visible in TC.
It brings two benefits:
1 - we can use any annotation for any platform to ignore tests, not only `@Ignored` for Android. And there's no more hardcoded filter in the `AndroidDeviceTestRunner` class. 
2 - we can disable some list of tests, but leave trail of it. For example, by this way I remove from mergebot's run all muted tests (really, why we need to spend resources if nobody will see it?), but they are visible in report: `Tests failed: 1 (1 new), passed: 607, ignored: 39`

Android users need to add the following to the Marathon file:

```
 filteringConfiguration:
   ignorelist:
   - type: "annotation"
     regex: "org.junit.Ignore"
```

4. I changed many names from `finished` to `passed`, because it's not the same. This inaccuracy greatly reduces code readability.

5. Implemented easy karma-counter for device. Probably, constants should be configurable. 

_Wasn't done yet:_

1. Incomplete tests didn't come to reports. I tried, but it too difficult because of current implementation of an analytics. I really hope for a quick refactoring.

2. I didn't fix tests. I have never even run them. I am ashamed, yes.

3. I didn't think how these changes will affect the iOS. All iOS classes changed only to make them compilable. 

4. There are some comments and inconsistent names in the code. TBD.

