### PR TITLE
Allow to disable HostKey verification for iOS

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileIOSConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileIOSConfiguration.kt
@@ -35,6 +35,7 @@ data class FileIOSConfiguration(
         @JsonProperty("keepAliveIntervalMillis") val keepAliveIntervalMillis: Long = 0L,
         @JsonProperty("deviceInitializationTimeoutMillis") val deviceInitializationTimeoutMillis: Long?,
         @JsonProperty("devices") val devices: File?,
+        @JsonProperty("disableHostKeyVerifier") val disableHostKeyVerifier: Boolean = false,
         val fileListProvider: FileListProvider = DerivedDataFileListProvider) : FileVendorConfiguration {
 
     fun toIOSConfiguration(marathonfileDir: File,
@@ -74,7 +75,8 @@ data class FileIOSConfiguration(
                     devicesFile = optionalDevices,
                     sourceRootsRegex = sourceRootsRegex,
                     sourceTargetName = sourceTargetName,
-                    binaryParserDockerImageName = binaryParserDockerImageName)
+                    binaryParserDockerImageName = binaryParserDockerImageName,
+                    disableHostKeyVerifier = disableHostKeyVerifier)
         } else {
             IOSConfiguration(
                     derivedDataDir = resolvedDerivedDataDir,
@@ -93,7 +95,8 @@ data class FileIOSConfiguration(
                     sourceRoot = optionalSourceRoot,
                     sourceRootsRegex = sourceRootsRegex,
                     sourceTargetName = sourceTargetName,
-                    binaryParserDockerImageName = binaryParserDockerImageName)
+                    binaryParserDockerImageName = binaryParserDockerImageName,
+                    disableHostKeyVerifier = disableHostKeyVerifier)
         }
     }
 }

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/DockerTestParser.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/DockerTestParser.kt
@@ -11,7 +11,7 @@ interface DockerTestParser {
     fun listTests(testRunnerPaths: List<File>): List<String>
 }
 
-class BinaryTestParser(private val binaryParserDockerImageName: String): DockerTestParser {
+class BinaryTestParser(private val binaryParserDockerImageName: String) : DockerTestParser {
     private val logger = MarathonLogging.logger(BinaryTestParser::class.java.simpleName)
 
     private class DockerOutputReader(private val inputStream: InputStream,
@@ -24,20 +24,18 @@ class BinaryTestParser(private val binaryParserDockerImageName: String): DockerT
 
     override fun listTests(testRunnerPaths: List<File>): List<String> {
         val pathMappings = testRunnerPaths.map {
-            it.absolutePath to File("/tmp").resolve(it.name).absolutePath }
+            it.absolutePath to File("/tmp").resolve(it.name).absolutePath
+        }
 
         val command =
-                listOf("docker", "run", "--rm") +
-                    pathMappings.map {
-                    listOf("-v", "${it.first}:${it.second}:ro") }
-                        .flatten() + binaryParserDockerImageName + pathMappings.map { it.second }
-
-        val builder = ProcessBuilder()
-                .command(command)
-                .directory(File(System.getProperty("user.dir")))
-        val process = builder.start()
+                listOf("docker", "run") +
+                        pathMappings
+                                .map { listOf("--rm", "-v", "${it.first}:${it.second}:ro") }
+                                .flatten() + binaryParserDockerImageName + pathMappings.map { "${it.second}" }
 
         val output = mutableListOf<String>()
+        val process = ProcessBuilder().command(command).start()
+
         val outputReader = DockerOutputReader(process.inputStream) { output.add(it) }
         Executors.newSingleThreadExecutor().submit(outputReader)
         return if (process.waitFor() == 0) {

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/DockerTestParser.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/DockerTestParser.kt
@@ -28,9 +28,9 @@ class BinaryTestParser(private val binaryParserDockerImageName: String) : Docker
         }
 
         val command =
-                listOf("docker", "run") +
+                listOf("docker", "run", "--rm") +
                         pathMappings
-                                .map { listOf("--rm", "-v", "${it.first}:${it.second}:ro") }
+                                .map { listOf("-v", "${it.first}:${it.second}:ro") }
                                 .flatten() + binaryParserDockerImageName + pathMappings.map { "${it.second}" }
 
         val output = mutableListOf<String>()

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSConfiguration.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSConfiguration.kt
@@ -23,7 +23,8 @@ data class IOSConfiguration(val derivedDataDir: File,
                             val sourceRoot: File = File("."),
                             val sourceRootsRegex: Regex?,
                             val sourceTargetName: String?,
-                            val binaryParserDockerImageName: String?) : VendorConfiguration {
+                            val binaryParserDockerImageName: String?,
+                            val disableHostKeyVerifier: Boolean = false) : VendorConfiguration {
 
     companion object {
         const val DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS: Long = 300_000

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/cmd/remote/SshjCommandExecutor.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/cmd/remote/SshjCommandExecutor.kt
@@ -23,7 +23,6 @@ import net.schmizz.sshj.common.LoggerFactory
 import net.schmizz.sshj.connection.ConnectionException
 import net.schmizz.sshj.connection.ConnectionImpl
 import net.schmizz.sshj.transport.TransportException
-import net.schmizz.sshj.transport.verification.OpenSSHKnownHosts
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.userauth.UserAuthException
 import org.slf4j.Logger
@@ -53,6 +52,8 @@ class SshjCommandExecutor(connectionId: String,
     override val coroutineContext: CoroutineContext
         get() = dispatcher
     private val ssh: SSHClient
+
+    private val logger = MarathonLogging.logger(SshjCommandExecutor::class.java.simpleName)
 
     init {
         val config = DefaultConfig()
@@ -91,6 +92,7 @@ class SshjCommandExecutor(connectionId: String,
             ssh = SSHClient(config)
             if (disableHostKeyVerifier) {
                 ssh.addHostKeyVerifier(PromiscuousVerifier())
+                logger.info("HostKey verification disabled")
             }
             if (keepAliveIntervalMillis > 0) {
                 ssh.connection.keepAlive.keepAliveInterval = (keepAliveIntervalMillis / 1000).toInt()
@@ -106,10 +108,6 @@ class SshjCommandExecutor(connectionId: String,
         } catch (e: ConnectException) {
             throw DeviceFailureException(DeviceFailureReason.Unknown, e)
         }
-    }
-
-    private val logger by lazy {
-        MarathonLogging.logger(SshjCommandExecutor::class.java.simpleName)
     }
 
     override fun startSession(command: String): CommandSession = SshjCommandSession(command, ssh)


### PR DESCRIPTION
#### CHANGELOG:
- [Add] `--rm` for every volume mapping in `docker run` command
- [Add] `disableHostKeyVerifier` configuration parameter to turn HostKey verification on demand.
- [Fix] an issue with loading default `known_hosts` even if the custom path is set.