### PR TITLE
fix(core): fix double upload of cli zip to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ jobs:
             tags: true
     - stage: deploy-cli
       script: ./gradlew :cli:assembleDist -PreleaseMode=RELEASE
+      before_deploy:
+        - rm -f cli/build/distributions/marathon-*-SNAPSHOT.zip || true
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
remove the snapshot file before uploading the release so that only the
release version is actually uploaded