### PR TITLE
fix(reporting): pool summary should expose final test event by default

### DIFF
--- a/.buildsystem/deploy-github.sh
+++ b/.buildsystem/deploy-github.sh
@@ -23,4 +23,6 @@ TARGETS=":core$DTASK :vendor:vendor-android$DTASK :marathon-gradle-plugin$DTASK 
 if [ -n "$TRAVIS_TAG" ]; then
   echo "on a tag -> deploy release version $TRAVIS_TAG"
   ./gradlew "$TARGETS" -PreleaseMode=RELEASE
+else
+  echo "not on a tag -> skipping deployment to GitHub"
 fi

--- a/.buildsystem/deploy-github.sh
+++ b/.buildsystem/deploy-github.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+cd $(dirname $0)/..
+
+if [ -z "$GITHUB_MAVEN_USERNAME" ]; then
+  echo "error: please set GITHUB_MAVEN_USERNAME environment variable"
+  exit 1
+fi
+
+if [ -z "$GITHUB_MAVEN_PASSWORD" ]; then
+  echo "error: please set GITHUB_MAVEN_PASSWORD environment variable"
+  exit 1
+fi
+
+if [ -z "$GPG_PASSPHRASE" ]; then
+  echo "error: please set GPG_PASSPHRASE environment variable"
+  exit 1
+fi
+
+DTASK=":publishDefaultPublicationToGitHubRepository"
+
+TARGETS=":core$DTASK :vendor:vendor-android$DTASK :marathon-gradle-plugin$DTASK :report:execution-timeline$DTASK :report:html-report$DTASK :analytics:usage$DTASK"
+
+if [ -n "$TRAVIS_TAG" ]; then
+  echo "on a tag -> deploy release version $TRAVIS_TAG"
+  ./gradlew "$TARGETS" -PreleaseMode=RELEASE
+fi

--- a/.buildsystem/deploy-sonatype.sh
+++ b/.buildsystem/deploy-sonatype.sh
@@ -2,7 +2,7 @@
 cd $(dirname $0)/..
 
 if [ -z "$SONATYPE_USERNAME" ]; then
-  echo "error: please set SONATYPE_USERNAME and SONATYPE_PASSWORD environment variable"
+  echo "error: please set SONATYPE_USERNAME environment variable"
   exit 1
 fi
 
@@ -20,10 +20,10 @@ DTASK=":publishDefaultPublicationToOSSHRRepository"
 
 TARGETS=":core$DTASK :vendor:vendor-android$DTASK :marathon-gradle-plugin$DTASK :report:execution-timeline$DTASK :report:html-report$DTASK :analytics:usage$DTASK"
 
-if [ ! -z "$TRAVIS_TAG" ]; then
-  echo "on a tag -> deploy release version $TRAVIS_TAG"
-  ./gradlew $TARGETS -PreleaseMode=RELEASE
-else
+if [ -z "$TRAVIS_TAG" ]; then
   echo "not on a tag -> deploy snapshot version"
-  ./gradlew $TARGETS -PreleaseMode=SNAPSHOT
+  ./gradlew "$TARGETS" -PreleaseMode=SNAPSHOT
+else
+  echo "on a tag -> deploy release version $TRAVIS_TAG"
+  ./gradlew "$TARGETS" -PreleaseMode=RELEASE
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ DerivedData
 *.ipa
 *.xcuserstate
 *.profraw
+sample/ios-app/Marathondevices

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,15 @@ jobs:
       script: skip
       deploy:
         - provider: script
-          script: bash .buildsystem/deploy.sh
+          script: bash .buildsystem/deploy-sonatype.sh
           on:
             branch: develop
         - provider: script
-          script: bash .buildsystem/deploy.sh
+          script: bash .buildsystem/deploy-sonatype.sh
+          on:
+            tags: true
+        - provider: script
+          script: bash .buildsystem/deploy-github.sh
           on:
             tags: true
     - stage: deploy-cli

--- a/buildSrc/src/main/kotlin/Deployment.kt
+++ b/buildSrc/src/main/kotlin/Deployment.kt
@@ -16,6 +16,8 @@ import java.net.URI
 object Deployment {
     val user = System.getenv("SONATYPE_USERNAME")
     val password = System.getenv("SONATYPE_PASSWORD")
+    val githubUser = System.getenv("GITHUB_MAVEN_USERNAME")
+    val githubPassword = System.getenv("GITHUB_MAVEN_PASSWORD")
     var releaseMode: String? = null
     var versionSuffix: String? = null
     var deployUrl: String? = null
@@ -24,6 +26,7 @@ object Deployment {
         ?: "https://oss.sonatype.org/content/repositories/snapshots/"
     val releaseDeployUrl = System.getenv("SONATYPE_RELEASES_URL")
         ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    val githubDeployUrl = "https://maven.pkg.github.com/Malinskiy"
 
     fun initialize(project: Project) {
         val releaseMode: String? by project
@@ -80,7 +83,15 @@ object Deployment {
                         username = Deployment.user
                         password = Deployment.password
                     }
-                    setUrl(URI.create(Deployment.deployUrl))
+                    url = URI.create(Deployment.deployUrl)
+                }
+                maven {
+                    name = "GitHub"
+                    credentials {
+                        username = Deployment.githubUser
+                        password = Deployment.githubPassword
+                    }
+                    url = URI.create(Deployment.githubDeployUrl)
                 }
             }
         }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
@@ -24,7 +24,10 @@ data class ExecutionReport(
     private fun compilePoolSummary(poolId: DevicePoolId): PoolSummary {
         val devices = deviceConnectedEvents.filter { it.poolId == poolId }.map { it.device }.distinctBy { it.serialNumber }
 
-        val tests = testEvents.filter { it.poolId == poolId }
+        val poolTestEvents = testEvents.filter { it.poolId == poolId }
+        val poolTestFinalEvents = poolTestEvents.filter { it.final }
+
+        val tests = poolTestFinalEvents
             .map { it.testResult }
             .filter { it.status != TestStatus.INCOMPLETE }
 
@@ -39,6 +42,18 @@ data class ExecutionReport(
                     && it.status != TestStatus.ASSUMPTION_FAILURE
         }
         val duration = tests.sumByDouble { it.durationMillis() * 1.0 }.toLong()
+
+        val rawTests = poolTestEvents
+            .map { it.testResult }
+        val rawPassed = rawTests.count { it.status == TestStatus.PASSED }
+        val rawIgnored = rawTests.count {
+            it.status == TestStatus.IGNORED
+                    || it.status == TestStatus.ASSUMPTION_FAILURE
+        }
+        val rawFailed = rawTests.count { it.status == TestStatus.FAILURE }
+        val rawIncomplete = rawTests.count { it.status == TestStatus.INCOMPLETE }
+        val rawDuration = rawTests.sumByDouble { it.durationMillis() * 1.0 }.toLong()
+
         return PoolSummary(
             poolId = poolId,
             tests = tests,
@@ -47,7 +62,12 @@ data class ExecutionReport(
             failed = failed,
             flaky = 0,
             durationMillis = duration,
-            devices = devices
+            devices = devices,
+            rawPassed = rawPassed,
+            rawFailed = rawFailed,
+            rawIgnored = rawIgnored,
+            rawIncomplete = rawIncomplete,
+            rawDurationMillis = rawDuration
         )
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
@@ -41,7 +41,7 @@ data class ExecutionReport(
                     && it.status != TestStatus.IGNORED
                     && it.status != TestStatus.ASSUMPTION_FAILURE
         }
-        val duration = tests.sumByDouble { it.durationMillis() * 1.0 }.toLong()
+        val duration = tests.map { it.durationMillis() }.sum()
 
         val rawTests = poolTestEvents
             .map { it.testResult }
@@ -52,7 +52,7 @@ data class ExecutionReport(
         }
         val rawFailed = rawTests.count { it.status == TestStatus.FAILURE }
         val rawIncomplete = rawTests.count { it.status == TestStatus.INCOMPLETE }
-        val rawDuration = rawTests.sumByDouble { it.durationMillis() * 1.0 }.toLong()
+        val rawDuration = rawTests.map { it.durationMillis() }.sum()
 
         return PoolSummary(
             poolId = poolId,

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
@@ -12,5 +12,10 @@ data class PoolSummary(
     val failed: Int,
     val flaky: Int,
     val durationMillis: Long,
-    val devices: List<DeviceInfo>
+    val devices: List<DeviceInfo>,
+    val rawPassed: Int,
+    val rawIgnored: Int,
+    val rawFailed: Int,
+    val rawIncomplete: Int,
+    val rawDurationMillis: Long
 )

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
@@ -12,7 +12,12 @@ class StdoutReporter(private val timer: Timer) : Reporter {
 
         val cliReportBuilder = StringBuilder().appendln("Marathon run finished:")
         summary.pools.forEach {
-            cliReportBuilder.appendln("Device pool ${it.poolId.name}: ${it.passed} passed, ${it.failed} failed, ${it.ignored} ignored tests")
+            cliReportBuilder.appendln(
+                "Device pool ${it.poolId.name}:\n" +
+                        "\t${it.passed} passed, ${it.failed} failed, ${it.ignored} ignored tests\n" +
+                        "\tFlakiness overhead: ${it.rawDurationMillis - it.durationMillis}ms\n" +
+                        "\tRaw: ${it.rawPassed} passed, ${it.rawFailed} failed, ${it.rawIgnored} ignored, ${it.rawIncomplete} incomplete tests"
+            )
         }
 
         val hours = TimeUnit.MILLISECONDS.toHours(timer.elapsedTimeMillis)


### PR DESCRIPTION
otherwise html reporters and stdout reporter print the raw numbers which
confuse users and also html reporter can't deal with the same test being
reported multiple times