### PR TITLE
Feature -- Enable Kaspresso steps listener

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.cli.args
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.android.AndroidConfiguration
+import com.malinskiy.marathon.android.DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER
 import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
 import com.malinskiy.marathon.android.defaultInitTimeoutMillis
 import com.malinskiy.marathon.android.serial.SerialStrategy
@@ -20,7 +21,8 @@ data class FileAndroidConfiguration(
     @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?,
     @JsonProperty("installOptions") val installOptions: String?,
     @JsonProperty("preferableRecorderType") val preferableRecorderType: DeviceFeature?,
-    @JsonProperty("serialStrategy") val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC
+    @JsonProperty("serialStrategy") val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
+    @JsonProperty("enableKaspressoStepsListener") val enableKaspressoStepsListener: Boolean?
 ) : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -39,7 +41,8 @@ data class FileAndroidConfiguration(
             adbInitTimeoutMillis = adbInitTimeoutMillis ?: defaultInitTimeoutMillis,
             installOptions = installOptions ?: DEFAULT_INSTALL_OPTIONS,
             preferableRecorderType = preferableRecorderType,
-            serialStrategy = serialStrategy
+            serialStrategy = serialStrategy,
+            enableKaspressoStepsListener = enableKaspressoStepsListener ?: DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER
         )
     }
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationSpek.kt
@@ -24,7 +24,8 @@ object FileAndroidConfigurationSpek : Spek(
                     null,
                     null,
                     null,
-                    SerialStrategy.AUTOMATIC
+                    SerialStrategy.AUTOMATIC,
+                    null
                 )
             }
 
@@ -81,6 +82,17 @@ object FileAndroidConfigurationSpek : Spek(
                 }
                 it("should be equal if provided") {
                     configuration.copy(installOptions = "-d").toAndroidConfiguration(env).installOptions shouldEqual "-d"
+                }
+            }
+            group("enable Kaspresso steps listener") {
+                it("should be false by default") {
+                    configuration.toAndroidConfiguration(env).enableKaspressoStepsListener shouldEqual false
+                }
+                it("should be equal") {
+                    configuration.copy(enableKaspressoStepsListener = false)
+                        .toAndroidConfiguration(env).enableKaspressoStepsListener shouldEqual false
+                    configuration.copy(enableKaspressoStepsListener = true)
+                        .toAndroidConfiguration(env).enableKaspressoStepsListener shouldEqual true
                 }
             }
         }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -162,7 +162,8 @@ object ConfigFactorySpec : Spek(
                         30_000,
                         "-d",
                         DeviceFeature.SCREENSHOT,
-                        SerialStrategy.AUTOMATIC
+                        SerialStrategy.AUTOMATIC,
+                        true
                     )
                 }
             }
@@ -230,7 +231,8 @@ object ConfigFactorySpec : Spek(
                         30_000,
                         "",
                         null,
-                        SerialStrategy.AUTOMATIC
+                        SerialStrategy.AUTOMATIC,
+                        false
                     )
                 }
             }
@@ -297,7 +299,8 @@ object ConfigFactorySpec : Spek(
                         30_000,
                         "",
                         null,
-                        SerialStrategy.HOSTNAME
+                        SerialStrategy.HOSTNAME,
+                        false
                     )
                 }
             }

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -75,3 +75,4 @@ vendorConfiguration:
     debug: "false"
   installOptions: "-d"
   preferableRecorderType: "screenshot"
+  enableKaspressoStepsListener: true

--- a/cli/src/test/resources/fixture/config/sample_1_rp.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1_rp.yaml
@@ -81,3 +81,4 @@ vendorConfiguration:
     debug: "false"
   installOptions: "-d"
   preferableRecorderType: "screenshot"
+  enableKaspressoStepsListener: true

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
@@ -10,7 +10,8 @@ data class TestResult(
     val startTime: Long,
     val endTime: Long,
     val stacktrace: String? = null,
-    val attachments: List<Attachment> = emptyList()
+    val attachments: List<Attachment> = emptyList(),
+    val stepsJson: String? = null
 ) {
     fun durationMillis() = endTime - startTime
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/steps/AllureStageDeserializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/steps/AllureStageDeserializer.kt
@@ -1,0 +1,22 @@
+package com.malinskiy.marathon.report.allure.steps
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import io.qameta.allure.model.Stage
+import java.lang.IllegalStateException
+import java.lang.reflect.Type
+
+
+class AllureStageDeserializer : JsonDeserializer<Stage> {
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Stage {
+        if (json is JsonPrimitive) {
+            return Stage.fromValue(json.asString)
+        } else {
+            throw IllegalStateException()
+        }
+    }
+
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/steps/AllureStatusDeserializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/steps/AllureStatusDeserializer.kt
@@ -1,0 +1,20 @@
+package com.malinskiy.marathon.report.allure.steps
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import io.qameta.allure.model.Status
+import java.lang.reflect.Type
+
+
+class AllureStatusDeserializer : JsonDeserializer<Status> {
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Status {
+        if (json is JsonPrimitive) {
+            return Status.fromValue(json.asString)
+        } else {
+            throw IllegalStateException()
+        }
+    }
+
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/steps/StepsJsonProvider.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/steps/StepsJsonProvider.kt
@@ -1,0 +1,13 @@
+package com.malinskiy.marathon.report.steps
+
+
+import com.malinskiy.marathon.test.Test
+
+
+interface StepsJsonProvider {
+    fun registerListener(listener: StepsJsonListener)
+}
+
+interface StepsJsonListener {
+    fun onStepsJsonAttached(test: Test, stepsJson: String)
+}

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -45,6 +45,7 @@ open class MarathonExtension(project: Project) {
     //Android specific for now
     var autoGrantPermission: Boolean? = null
     var instrumentationArgs: MutableMap<String, String> = mutableMapOf()
+    var enableKaspressoStepsListener: Boolean? = null
 
     //Kotlin way
     fun analytics(block: AnalyticsConfig.() -> Unit) {

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -5,8 +5,10 @@ import com.android.build.gradle.api.TestVariant
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.DEFAULT_APPLICATION_PM_CLEAR
 import com.malinskiy.marathon.android.DEFAULT_AUTO_GRANT_PERMISSION
+import com.malinskiy.marathon.android.DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER
 import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
 import com.malinskiy.marathon.android.defaultInitTimeoutMillis
+import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.di.marathonStartKoin
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.extensions.extractApplication
@@ -105,6 +107,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val adbInitTimeout = extension.adbInitTimeout ?: defaultInitTimeoutMillis
         val installOptions = extension.installOptions ?: DEFAULT_INSTALL_OPTIONS
         val preferableRecorderType = extension.preferableRecorderType
+        val enableKaspressoStepsListener = extension.enableKaspressoStepsListener ?: DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER
 
         return AndroidConfiguration(
             sdk,
@@ -116,7 +119,9 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
             testApplicationPmClear,
             adbInitTimeout,
             installOptions,
-            preferableRecorderType
+            preferableRecorderType,
+            SerialStrategy.AUTOMATIC,
+            enableKaspressoStepsListener
         )
     }
 

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -17,6 +17,7 @@ const val DEFAULT_AUTO_GRANT_PERMISSION = false
 const val DEFAULT_APPLICATION_PM_CLEAR = false
 const val DEFAULT_TEST_APPLICATION_PM_CLEAR = false
 const val DEFAULT_INSTALL_OPTIONS = ""
+const val DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER = false
 
 data class AndroidConfiguration(
     val androidSdk: File,
@@ -29,7 +30,8 @@ data class AndroidConfiguration(
     val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis,
     val installOptions: String = DEFAULT_INSTALL_OPTIONS,
     val preferableRecorderType: DeviceFeature? = null,
-    val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC
+    val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
+    val enableKaspressoStepsListener: Boolean = DEFAULT_ENABLE_KASPRESSO_STEPS_LISTENER
 ) : VendorConfiguration, KoinComponent {
 
     override fun testParser(): TestParser? = get()

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/LogCatListener.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/LogCatListener.kt
@@ -9,9 +9,12 @@ import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.device.toDeviceInfo
 import com.malinskiy.marathon.execution.Attachment
 import com.malinskiy.marathon.execution.AttachmentType
+import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.attachment.AttachmentListener
 import com.malinskiy.marathon.report.attachment.AttachmentProvider
 import com.malinskiy.marathon.report.logs.LogWriter
+import com.malinskiy.marathon.report.steps.StepsJsonListener
+import com.malinskiy.marathon.report.steps.StepsJsonProvider
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 
@@ -19,11 +22,24 @@ class LogCatListener(
     private val device: AndroidDevice,
     private val devicePoolId: DevicePoolId,
     private val logWriter: LogWriter
-) : NoOpTestRunListener(), AttachmentProvider {
+) : NoOpTestRunListener(), AttachmentProvider, StepsJsonProvider {
+
+    companion object {
+        private const val ALLURE_STEPS_JSON_PREFIX = "#AllureStepsInfoJson#:"
+        private const val TAG_KASPRESSO = "KASPRESSO"
+        private const val KASPRESSO_AFTER_TEST_SECTION = "AFTER TEST SECTION"
+    }
+
+    private val logger = MarathonLogging.logger {}
     private val attachmentListeners = mutableListOf<AttachmentListener>()
+    private val stepsJsonListeners = mutableListOf<StepsJsonListener>()
 
     override fun registerListener(listener: AttachmentListener) {
         attachmentListeners.add(listener)
+    }
+
+    override fun registerListener(listener: StepsJsonListener) {
+        stepsJsonListeners.add(listener)
     }
 
     private val receiver = LogCatReceiverTask(device.ddmsDevice)
@@ -44,11 +60,31 @@ class LogCatListener(
 
     override fun testEnded(test: TestIdentifier, testMetrics: Map<String, String>) {
         val messages = ref.getAndSet(mutableListOf())
-        val file = logWriter.saveLogs(test.toTest(), devicePoolId, device.toDeviceInfo(), messages.map {
-            "${it.timestamp} ${it.pid}-${it.tid}/${it.appName} ${it.logLevel.priorityLetter}/${it.tag}: ${it.message}"
-        })
 
-        attachmentListeners.forEach { it.onAttachment(test.toTest(), Attachment(file, AttachmentType.LOG)) }
+        val stepsJson = StringBuilder("")
+        val needSearchStepsJsonMessages = stepsJsonListeners.isNotEmpty()
+        val logMessages = messages.map {
+            if (needSearchStepsJsonMessages) {
+                when {
+                    it.message.startsWith(ALLURE_STEPS_JSON_PREFIX) -> {
+                        stepsJson.append(it.message.substring(ALLURE_STEPS_JSON_PREFIX.length))
+                    }
+
+                    it.tag == TAG_KASPRESSO && it.message == KASPRESSO_AFTER_TEST_SECTION -> {
+                        logger.info { "Find logs from another test! Reset stepsJson." }
+                        stepsJson.setLength(0)
+                    }
+                }
+            }
+            "${it.timestamp} ${it.pid}-${it.tid}/${it.appName} ${it.logLevel.priorityLetter}/${it.tag}: ${it.message}"
+        }
+        val testIdentifier = test.toTest()
+        val file = logWriter.saveLogs(testIdentifier, devicePoolId, device.toDeviceInfo(), logMessages)
+
+        attachmentListeners.forEach { it.onAttachment(testIdentifier, Attachment(file, AttachmentType.LOG)) }
+        if (stepsJson.isNotBlank()) {
+            stepsJsonListeners.forEach { it.onStepsJsonAttached(testIdentifier, stepsJson.toString()) }
+        }
     }
 
     override fun testRunEnded(elapsedTime: Long, runMetrics: Map<String, String>) {


### PR DESCRIPTION
This PR adding new feature - enabling listener for test steps from [Kaspresso](https://github.com/KasperskyLab/Kaspresso) framework.

This works in the following way:

1. UI test created with TestCase from Kaspresso can hold a lot of steps with any description, e.g

```
@RunWith(AndroidJUnit4::class)
class OpenHomeScreenTest : TestCase() {

    @Rule
    @JvmField
    val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
            Manifest.permission.WRITE_EXTERNAL_STORAGE,
            Manifest.permission.READ_EXTERNAL_STORAGE
    )

    @Rule
    @JvmField
    val activityTestRule = ActivityTestRule(ApplicantRootActivity::class.java, true, false)

    @Test
    fun openHomeScreen() {
        before {
//            device.exploit.setOrientation(Orientation.Landscape)
            activityTestRule.launchActivity(null)

            waitSeconds(5)
        }.after {
//            device.exploit.setOrientation(Orientation.Portrait)
        }.run {
            step("Open Home Screen") {
                step("First sub step") {

                }
                step("Second sub step") {
                    step("Unexpected step") {

                    }
                }
            }
            step("Another step to show several steps") {

            }
        }
    }

}
```

Kaspresso itself [collects all steps](https://github.com/KasperskyLab/Kaspresso/pull/4), and when test finished, writes collected steps info JSON into log, something like this:

```
I/KASPRESSO: #AllureStepsInfoJson#: [{"attachments":[],"name":"My step 1","parameters":[],"stage":"finished","start":1568790287246,"status":"passed", "steps":[],"stop":1568790288184}]
```

This info then can be read with *LogCatListener* in Marathon. After reading, this JSON will be propagated into Marathon's *TestResult*. And after all, this JSON will be converted into Allure's steps and forwarded into Allure's report. 

===

This feature can be enabled with Marathon's configuration file, by setting special flag in Android's vendorConfiguration:

```
vendorConfiguration:
  type: "Android"
  ...
  enableKaspressoStepsListener: true
```

By default, this feature is *disabled*. 