### PR TITLE
Add small optimization for ignored tests

### DIFF
--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -39,11 +39,12 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
         val info = ApkParser().parseInstrumentationInfo(androidConfiguration.testApplicationOutput)
         val runner = prepareTestRunner(configuration, androidConfiguration, info, testBatch)
 
-
         try {
-            clearData(androidConfiguration, info)
             notifyIgnoredTest(ignoredTests, listener)
-            runner.run(listener)
+            if (testBatch.tests.isNotEmpty()) {
+                clearData(androidConfiguration, info)
+                runner.run(listener)
+            }
         } catch (e: ShellCommandUnresponsiveException) {
             logger.warn(ERROR_STUCK)
             listener.testRunFailed(ERROR_STUCK)


### PR DESCRIPTION
In case if all tests are ignored in batch and we have 0 tests to execute we don't need to cleanup data and start execution.