### PR TITLE
fix(test parsing): support both xTest and xTests as default class name

### DIFF
--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -211,7 +211,7 @@ object ConfigFactorySpec : Spek(
                     configuration.filteringConfiguration.whitelist.shouldBeEmpty()
                     configuration.filteringConfiguration.blacklist.shouldBeEmpty()
 
-                    configuration.testClassRegexes.map { it.toString() } shouldContainAll listOf("^((?!Abstract).)*Test$")
+                    configuration.testClassRegexes.map { it.toString() } shouldContainAll listOf("^((?!Abstract).)*Test[s]*$")
 
                     configuration.includeSerialRegexes shouldEqual emptyList()
                     configuration.excludeSerialRegexes shouldEqual emptyList()

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -98,7 +98,7 @@ data class Configuration constructor(
                 fallbackToScreenshots = fallbackToScreenshots ?: false,
                 strictMode = strictMode ?: false,
                 uncompletedTestRetryQuota = uncompletedTestRetryQuota ?: Integer.MAX_VALUE,
-                testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test$")),
+                testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test[s]*$")),
                 includeSerialRegexes = includeSerialRegexes ?: emptyList(),
                 excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
                 testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,


### PR DESCRIPTION
Currently the iOS tests are usually written as xxTests. The default regex support only the xxTest. This should support both scenarios without having to specify `testClassRegexes: ["^((?!Abstract).)*Tests$"]`