### PR TITLE
feat(Android): Add support for code coverage

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -17,6 +17,12 @@ class FileManager(private val output: File) {
         return createFile(directory, filename)
     }
 
+    fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo, suffix: String): File {
+        val directory = createDirectory(fileType, pool)
+        val filename = createFilename(device, suffix, fileType)
+        return createFile(directory, filename)
+    }
+
     fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo): File {
         val directory = createDirectory(fileType, pool)
         val filename = createFilename(device, fileType)
@@ -51,4 +57,6 @@ class FileManager(private val output: File) {
     private fun createFilename(test: Test, fileType: FileType): String = "${test.toTestName()}.${fileType.suffix}"
 
     private fun createFilename(device: DeviceInfo, fileType: FileType): String = "${device.serialNumber}.${fileType.suffix}"
+
+    private fun createFilename(device: DeviceInfo, suffix: String, fileType: FileType): String = "${device.serialNumber}-$suffix.${fileType.suffix}"
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileType.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileType.kt
@@ -7,6 +7,6 @@ enum class FileType(val dir: String, val suffix: String) {
     LOG("logs", "log"),
     DEVICE_INFO("devices", "json"),
     VIDEO("video", "mp4"),
-    SCREENSHOT("screenshot", "gif")
-
+    SCREENSHOT("screenshot", "gif"),
+    COVERAGE("coverage", "ec")
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/test/TestBatch.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/test/TestBatch.kt
@@ -1,3 +1,5 @@
 package com.malinskiy.marathon.test
 
-data class TestBatch(val tests: List<Test>)
+import java.util.UUID
+
+data class TestBatch(val tests: List<Test>,  val id: String = UUID.randomUUID().toString())

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -6,6 +6,7 @@ import com.malinskiy.marathon.android.configuration.SerialStrategy
 import com.malinskiy.marathon.android.exception.InvalidSerialConfiguration
 import com.malinskiy.marathon.android.exception.TransferException
 import com.malinskiy.marathon.android.executor.listeners.AllureArtifactsTestRunListener
+import com.malinskiy.marathon.android.executor.listeners.CodeCoverageListener
 import com.malinskiy.marathon.android.executor.listeners.CompositeTestRunListener
 import com.malinskiy.marathon.android.executor.listeners.DebugTestRunListener
 import com.malinskiy.marathon.android.executor.listeners.LogCatListener
@@ -226,6 +227,10 @@ abstract class BaseAndroidDevice(
         val recorderListener = selectRecorderType(features, recordConfiguration)?.let { feature ->
             prepareRecorderListener(feature, fileManager, devicePoolId, screenRecordingPolicy, attachmentProviders)
         } ?: NoOpTestRunListener()
+        val coverageListener = when (configuration.isCodeCoverageEnabled) {
+            true -> CodeCoverageListener(this, devicePoolId, fileManager, testBatch)
+            false -> NoOpTestRunListener()
+        }
         val allureListener = when (this@BaseAndroidDevice.configuration.allureConfiguration.enabled) {
             false -> NoOpTestRunListener()
             true -> AllureArtifactsTestRunListener(this, this@BaseAndroidDevice.configuration.allureConfiguration, fileManager)
@@ -236,6 +241,7 @@ abstract class BaseAndroidDevice(
 
         return CompositeTestRunListener(
             listOf(
+                coverageListener,
                 recorderListener,
                 logCatListener,
                 TestRunResultsListener(testBatch, this, deferred, timer, attachmentProviders),

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/CodeCoverageListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/CodeCoverageListener.kt
@@ -1,0 +1,30 @@
+package com.malinskiy.marathon.android.executor.listeners
+
+import com.malinskiy.marathon.android.AndroidDevice
+import com.malinskiy.marathon.android.model.TestIdentifier
+import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.device.toDeviceInfo
+import com.malinskiy.marathon.io.FileManager
+import com.malinskiy.marathon.io.FileType
+import com.malinskiy.marathon.log.MarathonLogging
+import com.malinskiy.marathon.test.TestBatch
+
+class CodeCoverageListener(
+    private val device: AndroidDevice,
+    private val devicePoolId: DevicePoolId,
+    private val fileManager: FileManager,
+    private val testBatch: TestBatch
+) : NoOpTestRunListener() {
+    private val logger = MarathonLogging.logger("CodeCoverageListener")
+
+    override suspend fun testRunEnded(elapsedTime: Long, runMetrics: Map<String, String>) {
+        val src = "${device.externalStorageMount}/coverage-${testBatch.id}.ec"
+        val dest = fileManager.createFile(FileType.COVERAGE, devicePoolId, device.toDeviceInfo(), testBatch.id).absolutePath
+
+        try {
+            device.pullFile(src, dest)
+        } catch (e: Exception) {
+            logger.error("Downloading coverage file $src failed!", e)
+        }
+    }
+}

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -33,7 +33,7 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
         val ignoredTests = rawTestBatch.tests.filter { test ->
             test.metaProperties.any { it.name == JUNIT_IGNORE_META_PROPERTY_NAME }
         }
-        val testBatch = TestBatch(rawTestBatch.tests - ignoredTests)
+        val testBatch = TestBatch(rawTestBatch.tests - ignoredTests, rawTestBatch.id)
 
         val androidConfiguration = configuration.vendorConfiguration as AndroidConfiguration
         val info = ApkParser().parseInstrumentationInfo(androidConfiguration.testApplicationOutput)
@@ -116,6 +116,11 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
 
         androidConfiguration.instrumentationArgs.forEach { key, value ->
             runner.addInstrumentationArg(key, value)
+        }
+        if (configuration.isCodeCoverageEnabled) {
+            val dest = "${device.externalStorageMount}/coverage-${testBatch.id}.ec"
+            runner.addInstrumentationArg("coverage", "true")
+            runner.addInstrumentationArg("coverageFile", dest)
         }
 
         return runner


### PR DESCRIPTION
## Description

This PR will add support for generating code coverage files while running tests on an Android device (for instance, an Android emulator) as well as downloading these files to the Marathon report directory after the tests have finished.

The main changes are:

1) Making the `AndroidTestRunner` read the `Configuration.isCodeCoverageEnabled` flag. If it is set, two instrumentation arguments are added to the command for executing tests (see [Android Documentation](https://developer.android.com/reference/androidx/test/runner/AndroidJUnitRunner)):
    * `coverage=true`, for enabling code coverage in general
    * `coverageFile=<path-to-coverage-file>`, for saving the coverage data at a known path
2) Adding a new `CodeCoverageListener` to the test run listeners for downloading the generated code coverage file to the Marathon report directory on the host computer. For this I created the new enum case `FileType.COVERAGE`, such that the coverage files would end up in the subfolder `coverage`.

However, when executing the above one needs to be careful about the `<path-to-coverage-file>`. The problem is that when tests are executed in batches each test batch is a new command which is executed on the Android device. Assuming the `<path-to-coverage-file>` is a static path, this would mean that each test batch would overwrite the coverage data from the previous test batch.

To prevent this, the `<path-to-coverage-file>` needs to include some dynamic parts making the path for each test batch unique. At first I tried to add an increasing number as a suffix to the path. However, I couldn't find such a number which would be available with in the `AndroidTestRunner`. My second attempt was to use the tests included in an instance of `TestBatch` to generate a unique id. However, this id was either not really unique or too long for a file name. Thus I settled with generating and assigning a UUID to each `TestBatch` instance upon creation. This is not guaranteed to be unique (as UUID are not guaranteed to be unique) but seemed to be unique enough (probability is super low).

## Screenshots

| Marathon Report |
|:---:|
| ![Bildschirmfoto 2019-12-13 um 12 38 35](https://user-images.githubusercontent.com/342095/70797820-997ae980-1da5-11ea-8d77-3eaad5fd5a13.png) |

## Open Questions

There are some known open questions that might need to be clarified before merging:

#### 1. Do you see the code coverage being merged into one file at some point?

Absolutely. In the project I'm currently working on we already have a Gradle task for doing this. This Gradle task was necessary anyways as the Android Test Orchestrator uses a similar approach to the one above and generates code coverage files for each test that is being run (with the above changes Marathon would do the same when the test batch size is set to 1). However, in order to generate XML/HTML coverage reports the developer has to merge these files as well. This can be done with a Gradle task like this:

```
task jacocoCoverageReport(type: JacocoReport) {
    group = "verification"
    description = "Converts JaCoCo coverage reports to XML/HTML reports."

    reports {
        xml.enabled = true
        html.enabled = true
    }

    sourceDirectories.from = files([sourceDir('app')])
    classDirectories.from = files([classDir('app')])
    executionData.from = fileTree(dir: rootDir, includes: ['**/*.exec', '**/*.ec'])
}
```

#### 2. What about potential clashes: one retry failed, another one succeeded for example?

I'm not perfectly sure, but I would assume that if the failed run covers the code paths A and B and the succeeded one covers the code paths A and C, the merged coverage files would mark the code paths A, B and C as covered.

As I did not touch existing code of Marathon, I would expect the HTML test report generated by Marathon to be unchanged compared to the current state 🙂.
