### PR TITLE
[Android] Allow to configure to keep video on success

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.cli.args
 
 import com.malinskiy.marathon.execution.AnalyticsConfiguration
 import com.malinskiy.marathon.execution.FilteringConfiguration
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.execution.strategy.FlakinessStrategy
 import com.malinskiy.marathon.execution.strategy.PoolingStrategy
@@ -37,7 +38,7 @@ data class FileConfiguration(
     var testOutputTimeoutMillis: Long?,
     var debug: Boolean?,
 
-    val screenRecordingPolicy: String?,
+    val screenRecordingPolicy: ScreenRecordingPolicy?,
 
     var vendorConfiguration: FileVendorConfiguration?,
 

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -37,6 +37,8 @@ data class FileConfiguration(
     var testOutputTimeoutMillis: Long?,
     var debug: Boolean?,
 
+    val screenRecordingPolicy: String?,
+
     var vendorConfiguration: FileVendorConfiguration?,
 
     var analyticsTracking: Boolean?

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -8,7 +8,6 @@ import com.malinskiy.marathon.cli.args.FileIOSConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import com.malinskiy.marathon.execution.Configuration
-import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.vendor.VendorConfiguration
 import org.apache.commons.text.StringSubstitutor
@@ -64,7 +63,7 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             testBatchTimeoutMillis = config.testBatchTimeoutMillis,
             testOutputTimeoutMillis = config.testOutputTimeoutMillis,
             debug = config.debug,
-            screenRecordingPolicy = ScreenRecordingPolicy.fromString(config.screenRecordingPolicy),
+            screenRecordingPolicy = config.screenRecordingPolicy,
             vendorConfiguration = vendorConfiguration as VendorConfiguration,
             analyticsTracking = config.analyticsTracking
         )

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -8,6 +8,7 @@ import com.malinskiy.marathon.cli.args.FileIOSConfiguration
 import com.malinskiy.marathon.cli.args.environment.EnvironmentReader
 import com.malinskiy.marathon.exceptions.ConfigurationException
 import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.vendor.VendorConfiguration
 import org.apache.commons.text.StringSubstitutor
@@ -63,6 +64,7 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             testBatchTimeoutMillis = config.testBatchTimeoutMillis,
             testOutputTimeoutMillis = config.testOutputTimeoutMillis,
             debug = config.debug,
+            screenRecordingPolicy = ScreenRecordingPolicy.fromString(config.screenRecordingPolicy),
             vendorConfiguration = vendorConfiguration as VendorConfiguration,
             analyticsTracking = config.analyticsTracking
         )

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/DeserializeModule.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/DeserializeModule.kt
@@ -13,12 +13,14 @@ import com.malinskiy.marathon.cli.config.deserialize.PoolingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.ProbabilityBasedFlakinessStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.RetentionPolicyConfigurationDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.RetryStrategyDeserializer
+import com.malinskiy.marathon.cli.config.deserialize.ScreenRecordingPolicyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.ShardingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.SortingStrategyDeserializer
 import com.malinskiy.marathon.cli.config.deserialize.TestFilterDeserializer
 import com.malinskiy.marathon.cli.config.time.InstantTimeProvider
 import com.malinskiy.marathon.execution.AnalyticsConfiguration
 import com.malinskiy.marathon.execution.TestFilter
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.execution.strategy.FlakinessStrategy
 import com.malinskiy.marathon.execution.strategy.PoolingStrategy
@@ -57,5 +59,6 @@ class DeserializeModule(instantTimeProvider: InstantTimeProvider) : SimpleModule
         addDeserializer(RetryStrategy::class.java, RetryStrategyDeserializer())
         addDeserializer(TestFilter::class.java, TestFilterDeserializer())
         addDeserializer(FileVendorConfiguration::class.java, FileVendorConfigurationDeserializer())
+        addDeserializer(ScreenRecordingPolicy::class.java, ScreenRecordingPolicyDeserializer())
     }
 }

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/ScreenRecordingPolicyDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/ScreenRecordingPolicyDeserializer.kt
@@ -1,0 +1,18 @@
+package com.malinskiy.marathon.cli.config.deserialize
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.malinskiy.marathon.exceptions.ConfigurationException
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
+
+class ScreenRecordingPolicyDeserializer : StdDeserializer<ScreenRecordingPolicy>(ScreenRecordingPolicy::class.java) {
+    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): ScreenRecordingPolicy? {
+        val value: String = p?.valueAsString ?: return null
+        return when (value) {
+            "ON_FAILURE" -> ScreenRecordingPolicy.ON_FAILURE
+            "ON_ANY" -> ScreenRecordingPolicy.ON_ANY
+            else -> throw ConfigurationException("Unrecognized screen recording policy $value")
+        }
+    }
+}

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -151,6 +151,7 @@ object ConfigFactorySpec : Spek(
                     configuration.testBatchTimeoutMillis shouldEqual 20_000
                     configuration.testOutputTimeoutMillis shouldEqual 30_000
                     configuration.debug shouldEqual true
+                    configuration.screenRecordingPolicy shouldEqual "ON_ANY"
 
                     configuration.vendorConfiguration shouldEqual AndroidConfiguration(
                         File("/local/android"),
@@ -221,6 +222,7 @@ object ConfigFactorySpec : Spek(
                     configuration.testBatchTimeoutMillis shouldEqual 900_000
                     configuration.testOutputTimeoutMillis shouldEqual 60_000
                     configuration.debug shouldEqual true
+                    configuration.screenRecordingPolicy shouldEqual "ON_FAILURE"
                     configuration.vendorConfiguration shouldEqual AndroidConfiguration(
                         File("/local/android"),
                         File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -19,6 +19,7 @@ import com.malinskiy.marathon.execution.FullyQualifiedClassnameFilter
 import com.malinskiy.marathon.execution.SimpleClassnameFilter
 import com.malinskiy.marathon.execution.TestMethodFilter
 import com.malinskiy.marathon.execution.TestPackageFilter
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.strategy.impl.batching.FixedSizeBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.batching.IsolateBatchingStrategy
 import com.malinskiy.marathon.execution.strategy.impl.flakiness.IgnoreFlakinessStrategy
@@ -151,7 +152,7 @@ object ConfigFactorySpec : Spek(
                     configuration.testBatchTimeoutMillis shouldEqual 20_000
                     configuration.testOutputTimeoutMillis shouldEqual 30_000
                     configuration.debug shouldEqual true
-                    configuration.screenRecordingPolicy shouldEqual "ON_ANY"
+                    configuration.screenRecordingPolicy shouldEqual ScreenRecordingPolicy.ON_ANY
 
                     configuration.vendorConfiguration shouldEqual AndroidConfiguration(
                         File("/local/android"),
@@ -222,7 +223,7 @@ object ConfigFactorySpec : Spek(
                     configuration.testBatchTimeoutMillis shouldEqual 900_000
                     configuration.testOutputTimeoutMillis shouldEqual 60_000
                     configuration.debug shouldEqual true
-                    configuration.screenRecordingPolicy shouldEqual "ON_FAILURE"
+                    configuration.screenRecordingPolicy shouldEqual ScreenRecordingPolicy.ON_FAILURE
                     configuration.vendorConfiguration shouldEqual AndroidConfiguration(
                         File("/local/android"),
                         File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -63,6 +63,7 @@ strictMode: true
 testBatchTimeoutMillis: 20000
 testOutputTimeoutMillis: 30000
 debug: true
+screenRecordingPolicy: "ON_ANY"
 vendorConfiguration:
   type: "Android"
   androidSdk: "/local/android"

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.execution
 
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.strategy.BatchingStrategy
 import com.malinskiy.marathon.execution.strategy.FlakinessStrategy
 import com.malinskiy.marathon.execution.strategy.PoolingStrategy
@@ -45,6 +46,8 @@ data class Configuration constructor(
     val testOutputTimeoutMillis: Long,
     val debug: Boolean,
 
+    val screenRecordingPolicy: ScreenRecordingPolicy,
+
     val vendorConfiguration: VendorConfiguration,
 
     val analyticsTracking: Boolean
@@ -77,6 +80,8 @@ data class Configuration constructor(
         testOutputTimeoutMillis: Long?,
         debug: Boolean?,
 
+        screenRecordingPolicy: ScreenRecordingPolicy?,
+
         vendorConfiguration: VendorConfiguration,
 
         analyticsTracking: Boolean?
@@ -104,6 +109,7 @@ data class Configuration constructor(
                 testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
                 testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
                 debug = debug ?: true,
+                screenRecordingPolicy = screenRecordingPolicy ?: ScreenRecordingPolicy.ON_FAILURE,
                 vendorConfiguration = vendorConfiguration,
                 analyticsTracking = analyticsTracking ?: false
             )
@@ -130,6 +136,7 @@ data class Configuration constructor(
             "testBatchTimeoutMillis" to testBatchTimeoutMillis.toString(),
             "testOutputTimeoutMillis" to testOutputTimeoutMillis.toString(),
             "debug" to debug.toString(),
+            "screenRecordingPolicy" to screenRecordingPolicy.toString(),
             "vendorConfiguration" to vendorConfiguration.toString()
         )
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
@@ -1,7 +1,5 @@
 package com.malinskiy.marathon.execution.policy
 
-import com.fasterxml.jackson.annotation.JsonCreator
-
 /**
  * Defines when screen recordings should be kept.
  */
@@ -14,17 +12,4 @@ enum class ScreenRecordingPolicy {
      * Keep screen recording in any case.
      */
     ON_ANY;
-
-    companion object {
-        @JvmStatic
-        @JsonCreator
-        fun fromString(key: String?): ScreenRecordingPolicy? {
-            return when (key) {
-                ON_ANY.name -> ON_ANY
-                ON_FAILURE.name -> ON_FAILURE
-                null -> null // in null case return nothing
-                else -> throw Exception("Wrong screen recording policy. Use one of ${values()}")
-            }
-        }
-    }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
@@ -1,0 +1,28 @@
+package com.malinskiy.marathon.execution.policy
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+/**
+ * Defines when screen recordings should be kept.
+ */
+enum class ScreenRecordingPolicy {
+    /**
+     * Keep screen recording only if the test failed. (Default)
+     */
+    ON_FAILURE,
+    /**
+     * Keep screen recording in any case.
+     */
+    ON_ANY;
+
+    companion object {
+        @JvmStatic
+        @JsonCreator
+        fun fromString(key: String?): ScreenRecordingPolicy? {
+            return when (key) {
+                ON_ANY.name -> ON_ANY
+                else -> ON_FAILURE
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/policy/ScreenRecordingPolicy.kt
@@ -21,7 +21,9 @@ enum class ScreenRecordingPolicy {
         fun fromString(key: String?): ScreenRecordingPolicy? {
             return when (key) {
                 ON_ANY.name -> ON_ANY
-                else -> ON_FAILURE
+                ON_FAILURE.name -> ON_FAILURE
+                null -> null // in null case return nothing
+                else -> throw Exception("Wrong screen recording policy. Use one of ${values()}")
             }
         }
     }

--- a/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactorySpek.kt
@@ -42,6 +42,7 @@ class MetricsProviderFactorySpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = object : VendorConfiguration {
                         override fun testParser(): TestParser? = null
                         override fun deviceProvider(): DeviceProvider? = null
@@ -85,6 +86,7 @@ class MetricsProviderFactorySpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = object : VendorConfiguration {
                         override fun testParser(): TestParser? = null
                         override fun deviceProvider(): DeviceProvider? = null
@@ -128,6 +130,7 @@ class MetricsProviderFactorySpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = object : VendorConfiguration {
                         override fun testParser(): TestParser? = null
                         override fun deviceProvider(): DeviceProvider? = null

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorSpek.kt
@@ -254,6 +254,7 @@ private val DEFAULT_CONFIGURATION = Configuration(
     testBatchTimeoutMillis = null,
     testOutputTimeoutMillis = null,
     debug = null,
+    screenRecordingPolicy = null,
     vendorConfiguration = TestVendorConfiguration(
         testParser = mock(),
         deviceProvider = mock()

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -52,6 +52,7 @@ object TestResultReporterSpec : Spek(
             testBatchTimeoutMillis = null,
             testOutputTimeoutMillis = null,
             debug = false,
+            screenRecordingPolicy = null,
             vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
             analyticsTracking = false
         )

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportSpek.kt
@@ -53,6 +53,7 @@ class ExecutionReportSpek : Spek(
             testBatchTimeoutMillis = null,
             testOutputTimeoutMillis = null,
             debug = null,
+            screenRecordingPolicy = null,
             vendorConfiguration = object : VendorConfiguration {
                 override fun testParser(): TestParser? = null
                 override fun deviceProvider(): DeviceProvider? = null

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon
 
 import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.device.DeviceFeature
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -33,6 +34,8 @@ open class MarathonExtension(project: Project) {
     var testBatchTimeoutMillis: Long? = null
     var testOutputTimeoutMillis: Long? = null
     var debug: Boolean? = null
+
+    val screenRecordingPolicy: ScreenRecordingPolicy? = null
 
     var applicationPmClear: Boolean? = null
     var testApplicationPmClear: Boolean? = null

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -73,6 +73,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
             extensionConfig.testBatchTimeoutMillis,
             extensionConfig.testOutputTimeoutMillis,
             extensionConfig.debug,
+            extensionConfig.screenRecordingPolicy,
             vendorConfiguration,
             extensionConfig.analyticsTracking
         )

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderTestRunListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderTestRunListener.kt
@@ -10,6 +10,7 @@ import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.device.toDeviceInfo
 import com.malinskiy.marathon.execution.Attachment
 import com.malinskiy.marathon.execution.AttachmentType
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
 import com.malinskiy.marathon.log.MarathonLogging
@@ -23,7 +24,8 @@ const val MS_IN_SECOND: Long = 1_000L
 class ScreenRecorderTestRunListener(
     private val fileManager: FileManager,
     private val pool: DevicePoolId,
-    private val device: AndroidDevice
+    private val device: AndroidDevice,
+    private val screenRecordingPolicy: ScreenRecordingPolicy
 ) : NoOpTestRunListener(), AttachmentProvider {
 
     val attachmentListeners = mutableListOf<AttachmentListener>()
@@ -69,7 +71,7 @@ class ScreenRecorderTestRunListener(
                 recorder?.join(awaitMillis)
             }
             logger.trace { "join ${join}ms" }
-            if (hasFailed) {
+            if (hasFailed || screenRecordingPolicy == ScreenRecordingPolicy.ON_ANY) {
                 val stop = measureTimeMillis {
                     screenRecorderStopper.stopScreenRecord()
                 }

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderTestRunListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/video/ScreenRecorderTestRunListener.kt
@@ -71,7 +71,7 @@ class ScreenRecorderTestRunListener(
                 recorder?.join(awaitMillis)
             }
             logger.trace { "join ${join}ms" }
-            if (hasFailed || screenRecordingPolicy == ScreenRecordingPolicy.ON_ANY) {
+            if (screenRecordingPolicy == ScreenRecordingPolicy.ON_ANY || hasFailed) {
                 val stop = measureTimeMillis {
                     screenRecorderStopper.stopScreenRecord()
                 }

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserSpek.kt
@@ -39,6 +39,7 @@ class AndroidTestParserSpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = AndroidConfiguration(
                         File(""),
                         applicationOutput = File(""),

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibAndroidDevice.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibAndroidDevice.kt
@@ -42,6 +42,7 @@ import com.malinskiy.marathon.device.NetworkState
 import com.malinskiy.marathon.device.OperatingSystem
 import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.TestBatchResults
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.progress.ProgressReporter
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.log.MarathonLogging
@@ -57,7 +58,6 @@ import java.awt.image.BufferedImage
 import java.io.IOException
 import java.util.*
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.coroutines.CoroutineContext
 
@@ -295,8 +295,9 @@ class DdmlibAndroidDevice(
         val features = this.deviceFeatures
 
         val preferableRecorderType = configuration.vendorConfiguration.preferableRecorderType()
+        val screenRecordingPolicy = configuration.screenRecordingPolicy
         val recorderListener = selectRecorderType(preferableRecorderType, features)?.let { feature ->
-            prepareRecorderListener(feature, fileManager, devicePoolId, attachmentProviders)
+            prepareRecorderListener(feature, fileManager, devicePoolId, screenRecordingPolicy, attachmentProviders)
         } ?: NoOpTestRunListener()
 
         val logCatListener = LogCatListener(this, devicePoolId, LogWriter(fileManager))
@@ -355,17 +356,17 @@ class DdmlibAndroidDevice(
     }
 
     private fun prepareRecorderListener(
-        feature: DeviceFeature, fileManager: FileManager, devicePoolId: DevicePoolId,
+        feature: DeviceFeature, fileManager: FileManager, devicePoolId: DevicePoolId, screenRecordingPolicy: ScreenRecordingPolicy,
         attachmentProviders: MutableList<AttachmentProvider>
     ): NoOpTestRunListener =
         when (feature) {
             DeviceFeature.VIDEO -> {
-                ScreenRecorderTestRunListener(fileManager, devicePoolId, this)
+                ScreenRecorderTestRunListener(fileManager, devicePoolId, this, screenRecordingPolicy)
                     .also { attachmentProviders.add(it) }
             }
 
             DeviceFeature.SCREENSHOT -> {
-                ScreenCapturerTestRunListener(fileManager, devicePoolId, this)
+                ScreenCapturerTestRunListener(fileManager, devicePoolId, this, screenRecordingPolicy)
                     .also { attachmentProviders.add(it) }
             }
         }

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerSpek.kt
@@ -62,6 +62,7 @@ class AndroidDeviceTestRunnerSpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = AndroidConfiguration(
                         File(""),
                         applicationOutput = File(""),
@@ -113,6 +114,7 @@ class AndroidDeviceTestRunnerSpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = AndroidConfiguration(
                         File(""),
                         applicationOutput = File(""),

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerSpek.kt
@@ -90,6 +90,7 @@ object DerivedDataManagerSpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = false,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = IOSConfiguration(
                         derivedDataDir = derivedDataDir,
                         xctestrunPath = xctestrunPath,

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserSpek.kt
@@ -43,6 +43,7 @@ object IOSTestParserSpek : Spek(
                     testBatchTimeoutMillis = null,
                     testOutputTimeoutMillis = null,
                     debug = null,
+                    screenRecordingPolicy = null,
                     vendorConfiguration = IOSConfiguration(
                         derivedDataDir = derivedDataDir,
                         xctestrunPath = xctestrunPath,

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.test.factory
 
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.execution.policy.ScreenRecordingPolicy
 import com.malinskiy.marathon.execution.strategy.FlakinessStrategy
 import com.malinskiy.marathon.execution.strategy.ShardingStrategy
 import com.malinskiy.marathon.test.Mocks
@@ -39,6 +40,7 @@ class ConfigurationFactory {
     var testBatchTimeoutMillis = null
     var testOutputTimeoutMillis = null
     var analyticsTracking = false
+    var screenRecordingPolicy: ScreenRecordingPolicy? = null
 
     fun tests(block: () -> List<Test>) {
         val testParser = vendorConfiguration.testParser()!!
@@ -73,6 +75,7 @@ class ConfigurationFactory {
             testBatchTimeoutMillis,
             testOutputTimeoutMillis,
             debug,
+            screenRecordingPolicy,
             vendorConfiguration,
             analyticsTracking
         )


### PR DESCRIPTION
- Introduce ScreenRecordingPolicy.kt 
  - integrate new global configuration for ScreenPolicy
  - add to test cases (1 default value, 1 interpreting value)
- add delete functionality for screenshot (GIF)
- delete GIF in case we don't want to keep it in SUCCESS state
  - only attach attachment if we kept the GIF

--------

- if not keeping ON_ANY or we had a failure
  - delete
- if we had ON_ANY
  - keep

Should fix: https://github.com/Malinskiy/marathon/issues/306