### PR TITLE
Junit report refactor

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -47,6 +47,7 @@ object Versions {
     val dokka = "0.9.17"
     val koin = "2.0.1"
     val jsonAssert = "1.5.0"
+    val xmlUnit ="2.6.3"
     val assertk = "0.19"
 }
 
@@ -108,6 +109,7 @@ object TestLibraries {
     val jupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.jupiterEngine}"
     val koin = "org.koin:koin-test:${Versions.koin}"
     val jsonAssert = "org.skyscreamer:jsonassert:${Versions.jsonAssert}"
+    val xmlUnit = "org.xmlunit:xmlunit-matchers:${Versions.xmlUnit}"
     val assertk = "com.willowtreeapps.assertk:assertk:${Versions.assertk}"
 
     val testContainers = "org.testcontainers:testcontainers:${Versions.testContainers}"

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
@@ -64,7 +64,7 @@ internal class TrackerFactory(
         return ExecutionReportGenerator(
             listOf(
                 DeviceInfoJsonReporter(fileManager, gson),
-                JUnitReporter(JUnitWriter(fileManager)),
+                JUnitReporter(JUnitWriter(configuration.outputDir)),
                 TimelineReporter(TimelineSummaryProvider(), gson, configuration.outputDir),
                 RawJsonReporter(fileManager, gson),
                 TestJsonReporter(fileManager, gson),

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -29,6 +29,12 @@ class FileManager(private val output: File) {
         return File(resultsFolder, filename)
     }
 
+    fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo, fileName: String): File {
+        val directory = createDirectory(fileType, pool, device)
+        val filename = createFilename(fileName, fileType)
+        return createFile(directory, filename)
+    }
+
     private fun createDirectory(fileType: FileType, pool: DevicePoolId, device: DeviceInfo): Path =
         createDirectories(getDirectory(fileType, pool, device))
 
@@ -47,6 +53,8 @@ class FileManager(private val output: File) {
     private fun createFile(directory: Path, filename: String): File = File(directory.toFile(), filename)
 
     private fun createFilename(test: Test, fileType: FileType): String = "${test.toTestName()}.${fileType.suffix}"
+
+    private fun createFilename(filename: String, fileType: FileType): String = "${filename}.${fileType.suffix}"
 
     private fun createFilename(device: DeviceInfo, fileType: FileType): String = "${device.serialNumber}.${fileType.suffix}"
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -29,12 +29,6 @@ class FileManager(private val output: File) {
         return File(resultsFolder, filename)
     }
 
-    fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo, fileName: String): File {
-        val directory = createDirectory(fileType, pool, device)
-        val filename = createFilename(fileName, fileType)
-        return createFile(directory, filename)
-    }
-
     private fun createDirectory(fileType: FileType, pool: DevicePoolId, device: DeviceInfo): Path =
         createDirectories(getDirectory(fileType, pool, device))
 
@@ -53,8 +47,6 @@ class FileManager(private val output: File) {
     private fun createFile(directory: Path, filename: String): File = File(directory.toFile(), filename)
 
     private fun createFilename(test: Test, fileType: FileType): String = "${test.toTestName()}.${fileType.suffix}"
-
-    private fun createFilename(filename: String, fileType: FileType): String = "${filename}.${fileType.suffix}"
 
     private fun createFilename(device: DeviceInfo, fileType: FileType): String = "${device.serialNumber}.${fileType.suffix}"
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
@@ -5,6 +5,6 @@ import com.malinskiy.marathon.report.Reporter
 
 internal class JUnitReporter(private val jUnitWriter: JUnitWriter) : Reporter {
     override fun generate(executionReport: ExecutionReport) {
-        jUnitWriter.prepareXMLReport(executionReport)
+        jUnitWriter.prepareXMLReport(executionReport.testEvents.filter { it.final })
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
@@ -1,8 +1,6 @@
 package com.malinskiy.marathon.report.junit
 
 import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
-import com.malinskiy.marathon.device.DeviceInfo
-import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.report.Reporter
 
 internal class JUnitReporter(private val jUnitWriter: JUnitWriter) : Reporter {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitReporter.kt
@@ -1,12 +1,12 @@
 package com.malinskiy.marathon.report.junit
 
 import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
+import com.malinskiy.marathon.device.DeviceInfo
+import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.report.Reporter
 
 internal class JUnitReporter(private val jUnitWriter: JUnitWriter) : Reporter {
     override fun generate(executionReport: ExecutionReport) {
-        executionReport.testEvents.forEach { event ->
-            jUnitWriter.testFinished(event.poolId, event.device, event.testResult)
-        }
+        jUnitWriter.prepareXMLReport(executionReport)
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -1,16 +1,13 @@
 package com.malinskiy.marathon.report.junit
 
-import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
 import com.malinskiy.marathon.analytics.internal.sub.TestEvent
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
 import com.malinskiy.marathon.report.junit.model.JUnitReport
 import com.malinskiy.marathon.report.junit.model.Pool
-import org.testng.util.Strings
 import java.io.FileOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
-
 
 class JUnitWriter(private val fileManager: FileManager) {
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -5,6 +5,7 @@ import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
+import org.testng.util.Strings
 import java.io.FileOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
@@ -35,7 +36,10 @@ class JUnitWriter(private val fileManager: FileManager) {
         reportGenerator.makeSuiteData()
         val junitReports = reportGenerator.junitReports
         junitReports.keys.forEach {
-            generateXml(xmlWriterMap[it]!!, junitReports[it]!!)
+            val xmlWriter = xmlWriterMap[it]
+            val junitReport = junitReports[it]
+            if (xmlWriter != null && junitReport != null)
+                generateXml(xmlWriter, junitReport)
         }
     }
 
@@ -64,12 +68,8 @@ class JUnitWriter(private val fileManager: FileManager) {
                         attribute("classname", it.classname)
                         attribute("name", it.name)
                         attribute("time", it.time)
-                        if (it.skipped?.isNotEmpty()!!) {
-                            element("skipped", it.skipped)
-                        }
-                        if (it.failure?.isNotEmpty()!!) {
-                            element("failure", it.failure)
-                        }
+                        if (Strings.isNotNullAndNotEmpty(it.skipped)) element("skipped", it.skipped)
+                        if (Strings.isNotNullAndNotEmpty(it.failure)) element("failure", it.failure)
                     }
                 }
             }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -5,16 +5,19 @@ import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
+import com.malinskiy.marathon.report.junit.model.JUnitReport
+import com.malinskiy.marathon.report.junit.model.Pool
 import org.testng.util.Strings
 import java.io.FileOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
 
-private const val JUNIT_REPORT = "Marathon_Junit_Report"
 
 class JUnitWriter(private val fileManager: FileManager) {
 
-    private val xmlWriterMap = hashMapOf<DevicePool, XMLStreamWriter>()
+    private  val reportName = "marathon_junit_report"
+
+    private val xmlWriterMap = hashMapOf<Pool, XMLStreamWriter>()
 
     fun prepareXMLReport(executionReport: ExecutionReport) {
         makeFile(executionReport)
@@ -23,8 +26,9 @@ class JUnitWriter(private val fileManager: FileManager) {
     }
 
     private fun makeFile(executionReport: ExecutionReport) {
-        executionReport.testEvents.devicePools().forEach {
-            val file = fileManager.createFile(FileType.TEST, it.devicePool, it.deviceInfo, JUNIT_REPORT)
+        executionReport.testEvents.map { Pool(it.poolId, it.device) }.distinct()
+            .forEach {
+            val file = fileManager.createFile(FileType.TEST, it.devicePoolId, it.deviceInfo, reportName)
             file.createNewFile()
             val writer = XMLOutputFactory.newFactory().createXMLStreamWriter(FileOutputStream(file), "UTF-8")
             xmlWriterMap[it] = writer
@@ -76,8 +80,3 @@ class JUnitWriter(private val fileManager: FileManager) {
         }
     }
 }
-
-data class DevicePool(
-    val devicePool: DevicePoolId,
-    val deviceInfo: DeviceInfo
-)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -1,8 +1,6 @@
 package com.malinskiy.marathon.report.junit
 
 import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
-import com.malinskiy.marathon.device.DeviceInfo
-import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
 import com.malinskiy.marathon.report.junit.model.JUnitReport

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -1,15 +1,16 @@
 package com.malinskiy.marathon.report.junit
 
 import com.malinskiy.marathon.analytics.internal.sub.TestEvent
-import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.io.FileType
+import java.nio.file.Paths.get
 import com.malinskiy.marathon.report.junit.model.JUnitReport
 import com.malinskiy.marathon.report.junit.model.Pool
+import java.io.File
 import java.io.FileOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
 
-class JUnitWriter(private val fileManager: FileManager) {
+class JUnitWriter(private val outputDirectory: File) {
 
     private  val reportName = "marathon_junit_report"
 
@@ -24,10 +25,17 @@ class JUnitWriter(private val fileManager: FileManager) {
     private fun makeFile(testEvents: List<TestEvent>) {
         testEvents.map { Pool(it.poolId, it.device) }.distinct()
             .forEach {
-            val file = fileManager.createFile(FileType.TEST, it.devicePoolId, it.deviceInfo, reportName)
-            file.createNewFile()
-            val writer = XMLOutputFactory.newFactory().createXMLStreamWriter(FileOutputStream(file), "UTF-8")
-            xmlWriterMap[it] = writer
+                val reportDirectory = get(
+                    outputDirectory.absolutePath,
+                    FileType.TEST.dir,
+                    it.devicePoolId.name,
+                    it.deviceInfo.serialNumber)
+                    .toFile()
+                reportDirectory.mkdirs()
+                val file = File(reportDirectory.absolutePath,reportName+"."+FileType.TEST.suffix)
+                file.createNewFile()
+                val writer = XMLOutputFactory.newFactory().createXMLStreamWriter(FileOutputStream(file), "UTF-8")
+                xmlWriterMap[it] = writer
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/JUnitWriter.kt
@@ -68,8 +68,8 @@ class JUnitWriter(private val fileManager: FileManager) {
                         attribute("classname", it.classname)
                         attribute("name", it.name)
                         attribute("time", it.time)
-                        if (Strings.isNotNullAndNotEmpty(it.skipped)) element("skipped", it.skipped)
-                        if (Strings.isNotNullAndNotEmpty(it.failure)) element("failure", it.failure)
+                        if (Strings.isNotNullAndNotEmpty(it.skipped)) element("skipped") { writeCData(it.skipped) }
+                        if (Strings.isNotNullAndNotEmpty(it.failure)) element("failure") { writeCData(it.failure) }
                     }
                 }
             }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/TestInfoGenerator.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/TestInfoGenerator.kt
@@ -5,6 +5,7 @@ import com.malinskiy.marathon.execution.TestResult
 import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.report.junit.model.JUnitReport
 import com.malinskiy.marathon.report.junit.model.Pool
+import com.malinskiy.marathon.report.junit.model.StackTraceElement
 import com.malinskiy.marathon.report.junit.model.TestCaseData
 import com.malinskiy.marathon.report.junit.model.TestSuiteData
 import java.text.SimpleDateFormat
@@ -52,13 +53,14 @@ internal class JunitReportGenerator(private val testEvents: List<TestEvent>) {
                 classname = it.testResult.test.pkg + "." + it.testResult.test.clazz,
                 name = it.testResult.test.method,
                 time = it.testResult.durationMillis().toJUnitSeconds(),
-                skipped = if (isSkipped(it.testResult)) Objects.toString(it.testResult.stacktrace, "") else "",
-                failure = if (isFailure(it.testResult)) Objects.toString(it.testResult.stacktrace, "") else ""
+                skipped = if (isSkipped(it.testResult)) StackTraceElement(true, it.testResult.stacktrace) else StackTraceElement(false, null),
+                failure = if (isFailure(it.testResult)) StackTraceElement(true, it.testResult.stacktrace) else StackTraceElement(false, null)
             )
         }
 
     private fun isSkipped(testResult: TestResult) =
         testResult.status == TestStatus.IGNORED || testResult.status == TestStatus.ASSUMPTION_FAILURE
 
-    private fun isFailure(testResult: TestResult) = testResult.status == TestStatus.FAILURE
+    private fun isFailure(testResult: TestResult) =
+        testResult.status == TestStatus.FAILURE || testResult.status == TestStatus.INCOMPLETE
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/TestInfoGenerator.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/TestInfoGenerator.kt
@@ -1,0 +1,78 @@
+package com.malinskiy.marathon.report.junit
+
+import com.malinskiy.marathon.analytics.internal.sub.TestEvent
+import com.malinskiy.marathon.execution.TestStatus
+import java.text.SimpleDateFormat
+import java.util.*
+
+private val FORMATTER = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
+    timeZone = TimeZone.getTimeZone("UTC")
+}
+
+internal class JunitReportGenerator(private val testEvents: List<TestEvent>) {
+
+    @Suppress("MagicNumber")
+    private fun Long.toJUnitSeconds(): String = (this / 1000.0).toString()
+
+    var junitReports = hashMapOf<DevicePool, JUnitReport>()
+
+    fun makeSuiteData() {
+        val segregatedData = hashMapOf<DevicePool, List<TestEvent>>()
+        testEvents.devicePools().forEach { deviceData ->
+            segregatedData[deviceData] = testEvents.filter { it.device == deviceData.deviceInfo && it.poolId == deviceData.devicePool }
+        }
+        segregatedData.keys.forEach { deviceData ->
+            junitReports[deviceData] = JUnitReport(
+                segregatedData[deviceData]?.let { toTestSuite(it) }!!,
+                segregatedData[deviceData]?.let { toTestCase(it) }!!
+            )
+        }
+    }
+
+    private fun toTestSuite(testEvents: List<TestEvent>) =
+        TestSuiteData(
+            name = "common",
+            tests = testEvents.size,
+            failures = testEvents.filter { it.testResult.status == TestStatus.FAILURE }.size,
+            errors = 0,
+            skipped = testEvents.filter { it.testResult.status == TestStatus.IGNORED || it.testResult.status == TestStatus.ASSUMPTION_FAILURE }.size,
+            time = testEvents.map { it.testResult.durationMillis() }.sum().toJUnitSeconds(),
+            timeStamp = FORMATTER.format(testEvents.maxBy { it.testResult.endTime }?.testResult?.endTime!!)
+        )
+
+    private fun toTestCase(testEvents: List<TestEvent>) =
+        testEvents.map {
+            TestCaseData(
+                classname = it.testResult.test.pkg + "." + it.testResult.test.clazz,
+                name = it.testResult.test.method,
+                time = it.testResult.durationMillis().toJUnitSeconds(),
+                skipped = if (it.testResult.status == TestStatus.IGNORED || it.testResult.status == TestStatus.ASSUMPTION_FAILURE) it.testResult.stacktrace else "",
+                failure = if (it.testResult.status == TestStatus.FAILURE) it.testResult.stacktrace else ""
+            )
+        }
+}
+
+data class JUnitReport(
+    val testSuiteData: TestSuiteData,
+    val testCases: List<TestCaseData>
+)
+
+data class TestSuiteData(
+    val name: String,
+    val tests: Int,
+    val failures: Int,
+    val errors: Int,
+    val skipped: Int,
+    val time: String,
+    val timeStamp: String
+)
+
+data class TestCaseData(
+    val classname: String,
+    val name: String,
+    val time: String,
+    val skipped: String?,
+    val failure: String?
+)
+
+fun List<TestEvent>.devicePools() = this.map { DevicePool(it.poolId, it.device) }.distinct()

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/JUnitReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/JUnitReport.kt
@@ -1,8 +1,5 @@
 package com.malinskiy.marathon.report.junit.model
 
-import com.malinskiy.marathon.report.junit.TestCaseData
-import com.malinskiy.marathon.report.junit.TestSuiteData
-
 data class JUnitReport(
     val testSuiteData: TestSuiteData,
     val testCases: List<TestCaseData>

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/JUnitReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/JUnitReport.kt
@@ -1,0 +1,9 @@
+package com.malinskiy.marathon.report.junit.model
+
+import com.malinskiy.marathon.report.junit.TestCaseData
+import com.malinskiy.marathon.report.junit.TestSuiteData
+
+data class JUnitReport(
+    val testSuiteData: TestSuiteData,
+    val testCases: List<TestCaseData>
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/Pool.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/Pool.kt
@@ -1,0 +1,9 @@
+package com.malinskiy.marathon.report.junit.model
+
+import com.malinskiy.marathon.device.DeviceInfo
+import com.malinskiy.marathon.device.DevicePoolId
+
+data class Pool(
+    val devicePoolId: DevicePoolId,
+    val deviceInfo: DeviceInfo
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/StackTraceElement.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/StackTraceElement.kt
@@ -1,0 +1,6 @@
+package com.malinskiy.marathon.report.junit.model
+
+data class StackTraceElement(
+    val isError: Boolean,
+    val stackTrace: String?
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestCaseData.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestCaseData.kt
@@ -4,6 +4,6 @@ data class TestCaseData(
     val classname: String,
     val name: String,
     val time: String,
-    val skipped: String,
-    val failure: String
+    val skipped: StackTraceElement,
+    val failure: StackTraceElement
 )

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestCaseData.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestCaseData.kt
@@ -1,0 +1,9 @@
+package com.malinskiy.marathon.report.junit.model
+
+data class TestCaseData(
+    val classname: String,
+    val name: String,
+    val time: String,
+    val skipped: String,
+    val failure: String
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestSuiteData.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/junit/model/TestSuiteData.kt
@@ -1,0 +1,11 @@
+package com.malinskiy.marathon.report.junit.model
+
+data class TestSuiteData(
+    val name: String,
+    val tests: Int,
+    val failures: Int,
+    val errors: Int,
+    val skipped: Int,
+    val time: String,
+    val timeStamp: String
+)

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
@@ -78,6 +78,7 @@ class JUnitReporterSpek : Spek(
                 testBatchTimeoutMillis = null,
                 testOutputTimeoutMillis = null,
                 debug = null,
+                screenRecordingPolicy = null,
                 vendorConfiguration = object : VendorConfiguration {
                     override fun testParser(): TestParser? = null
                     override fun deviceProvider(): DeviceProvider? = null

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
@@ -14,7 +14,6 @@ import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.execution.TestResult
 import com.malinskiy.marathon.execution.TestStatus
-import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.log.MarathonLogConfigurator
 import com.malinskiy.marathon.report.junit.JUnitReporter
 import com.malinskiy.marathon.report.junit.JUnitWriter
@@ -116,7 +115,7 @@ class JUnitReporterSpek : Spek(
             val configuration = getConfiguration()
             println(configuration.outputDir)
             on("Marathon JUnit Report") {
-                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val jUnitWriter = JUnitWriter(configuration.outputDir)
                 val junitReport = JUnitReporter(jUnitWriter)
                 junitReport.generate(report)
                 it("should generate correct report") {
@@ -142,7 +141,7 @@ class JUnitReporterSpek : Spek(
             val configuration = getConfiguration()
             println(configuration.outputDir)
             on("Marathon JUnit Report") {
-                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val jUnitWriter = JUnitWriter(configuration.outputDir)
                 val junitReport = JUnitReporter(jUnitWriter)
                 junitReport.generate(report)
                 it("should generate correct report") {
@@ -173,7 +172,7 @@ class JUnitReporterSpek : Spek(
             val configuration = getConfiguration()
             println(configuration.outputDir)
             on("Marathon JUnit Report") {
-                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val jUnitWriter = JUnitWriter(configuration.outputDir)
                 val junitReport = JUnitReporter(jUnitWriter)
                 junitReport.generate(report)
                 it("should generate correct report") {
@@ -202,7 +201,7 @@ class JUnitReporterSpek : Spek(
             val configuration = getConfiguration()
             println(configuration.outputDir)
             on("Marathon JUnit Report") {
-                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val jUnitWriter = JUnitWriter(configuration.outputDir)
                 val junitReport = JUnitReporter(jUnitWriter)
                 junitReport.generate(report)
                 it("should generate correct report") {
@@ -231,7 +230,7 @@ class JUnitReporterSpek : Spek(
             val configuration = getConfiguration()
             println(configuration.outputDir)
             on("Marathon JUnit Report") {
-                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val jUnitWriter = JUnitWriter(configuration.outputDir)
                 val junitReport = JUnitReporter(jUnitWriter)
                 junitReport.generate(report)
                 it("should generate correct report") {

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterSpek.kt
@@ -1,0 +1,243 @@
+package com.malinskiy.marathon.report
+
+import com.malinskiy.marathon.analytics.internal.sub.DeviceConnectedEvent
+import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
+import com.malinskiy.marathon.analytics.internal.sub.TestEvent
+import com.malinskiy.marathon.device.DeviceFeature
+import com.malinskiy.marathon.device.DeviceInfo
+import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.device.DeviceProvider
+import com.malinskiy.marathon.device.NetworkState
+import com.malinskiy.marathon.device.OperatingSystem
+import com.malinskiy.marathon.execution.AnalyticsConfiguration
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.execution.TestParser
+import com.malinskiy.marathon.execution.TestResult
+import com.malinskiy.marathon.execution.TestStatus
+import com.malinskiy.marathon.io.FileManager
+import com.malinskiy.marathon.log.MarathonLogConfigurator
+import com.malinskiy.marathon.report.junit.JUnitReporter
+import com.malinskiy.marathon.report.junit.JUnitWriter
+import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.assert.shouldBeEqualToAsXML
+import com.malinskiy.marathon.vendor.VendorConfiguration
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import java.io.File
+import java.nio.file.Files
+import java.time.Instant
+
+class JUnitReporterSpek : Spek(
+    {
+
+        fun createTestEvent(
+            deviceInfo: DeviceInfo,
+            methodName: String,
+            status: TestStatus,
+            stackTrace: String? = null,
+            final: Boolean = true
+        ): TestEvent {
+            return TestEvent(
+                Instant.now(),
+                DevicePoolId("myPool"),
+                deviceInfo,
+                TestResult(
+                    Test("com", "example", methodName, emptyList()),
+                    deviceInfo,
+                    status,
+                    1541675929849,
+                    1541675941768,
+                    stackTrace
+                ),
+                final
+            )
+        }
+
+        fun getConfiguration() =
+            Configuration(
+                name = "",
+                outputDir = Files.createTempDirectory("test-run").toFile(),
+                analyticsConfiguration = AnalyticsConfiguration.DisabledAnalytics,
+                poolingStrategy = null,
+                shardingStrategy = null,
+                sortingStrategy = null,
+                batchingStrategy = null,
+                flakinessStrategy = null,
+                retryStrategy = null,
+                filteringConfiguration = null,
+                ignoreFailures = null,
+                isCodeCoverageEnabled = null,
+                fallbackToScreenshots = null,
+                strictMode = null,
+                uncompletedTestRetryQuota = null,
+                testClassRegexes = null,
+                includeSerialRegexes = null,
+                excludeSerialRegexes = null,
+                testBatchTimeoutMillis = null,
+                testOutputTimeoutMillis = null,
+                debug = null,
+                vendorConfiguration = object : VendorConfiguration {
+                    override fun testParser(): TestParser? = null
+                    override fun deviceProvider(): DeviceProvider? = null
+                    override fun logConfigurator(): MarathonLogConfigurator? = null
+                    override fun preferableRecorderType(): DeviceFeature? = null
+                },
+                analyticsTracking = false
+            )
+
+        fun getDevice() =
+            DeviceInfo(
+                operatingSystem = OperatingSystem("23"),
+                serialNumber = "xxyyzz",
+                model = "Android SDK built for x86",
+                manufacturer = "unknown",
+                networkState = NetworkState.CONNECTED,
+                deviceFeatures = listOf(DeviceFeature.SCREENSHOT, DeviceFeature.VIDEO),
+                healthy = true
+            )
+
+        given("an ExecutionReport with only Passed Tests and without retries") {
+            val device = getDevice()
+            val report = ExecutionReport(
+                deviceProviderPreparingEvent = emptyList(),
+                devicePreparingEvents = emptyList(),
+                deviceConnectedEvents = listOf(
+                    DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
+                ),
+                testEvents = listOf(
+                    createTestEvent(device, "test1", TestStatus.PASSED),
+                    createTestEvent(device, "test2", TestStatus.PASSED),
+                    createTestEvent(device, "test3", TestStatus.PASSED)
+                )
+            )
+            val configuration = getConfiguration()
+            println(configuration.outputDir)
+            on("Marathon JUnit Report") {
+                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val junitReport = JUnitReporter(jUnitWriter)
+                junitReport.generate(report)
+                it("should generate correct report") {
+                    File(configuration.outputDir.absolutePath + "/tests/myPool/xxyyzz/marathon_junit_report.xml")
+                        .shouldBeEqualToAsXML(File(javaClass.getResource("/output/tests/myPool/xxyyzz/marathon_junit_report_passed_tests.xml").file))
+                }
+            }
+        }
+        given("an ExecutionReport with only Failed Tests and without retries") {
+            val device = getDevice()
+            val report = ExecutionReport(
+                deviceProviderPreparingEvent = emptyList(),
+                devicePreparingEvents = emptyList(),
+                deviceConnectedEvents = listOf(
+                    DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
+                ),
+                testEvents = listOf(
+                    createTestEvent(device, "test1", TestStatus.FAILURE),
+                    createTestEvent(device, "test2", TestStatus.INCOMPLETE),
+                    createTestEvent(device, "test3", TestStatus.FAILURE)
+                )
+            )
+            val configuration = getConfiguration()
+            println(configuration.outputDir)
+            on("Marathon JUnit Report") {
+                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val junitReport = JUnitReporter(jUnitWriter)
+                junitReport.generate(report)
+                it("should generate correct report") {
+                    File(configuration.outputDir.absolutePath + "/tests/myPool/xxyyzz/marathon_junit_report.xml")
+                        .shouldBeEqualToAsXML(File(javaClass.getResource("/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests.xml").file))
+                }
+            }
+        }
+        given("an ExecutionReport with FAILURE, IGNORED, INCOMPLETE and ASSUMPTION_FAILURE Tests with stack trace") {
+            val device = getDevice()
+            val stackTrace = "Exception in thread \"main\" java.lang.RuntimeException: A test exception\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
+                "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
+            val report = ExecutionReport(
+                deviceProviderPreparingEvent = emptyList(),
+                devicePreparingEvents = emptyList(),
+                deviceConnectedEvents = listOf(
+                    DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
+                ),
+                testEvents = listOf(
+                    createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace),
+                    createTestEvent(device, "test2", TestStatus.IGNORED),
+                    createTestEvent(device, "test2", TestStatus.INCOMPLETE),
+                    createTestEvent(device, "test3", TestStatus.ASSUMPTION_FAILURE, stackTrace)
+                )
+            )
+            val configuration = getConfiguration()
+            println(configuration.outputDir)
+            on("Marathon JUnit Report") {
+                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val junitReport = JUnitReporter(jUnitWriter)
+                junitReport.generate(report)
+                it("should generate correct report") {
+                    File(configuration.outputDir.absolutePath + "/tests/myPool/xxyyzz/marathon_junit_report.xml")
+                        .shouldBeEqualToAsXML(File(javaClass.getResource("/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests_with_stacktrace.xml").file))
+                }
+            }
+        }
+        given("an ExecutionReport with multiple execution of the same test from FAILURE to PASSED") {
+            val device = getDevice()
+            val stackTrace = "Exception in thread \"main\" java.lang.RuntimeException: A test exception\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
+                "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
+            val report = ExecutionReport(
+                deviceProviderPreparingEvent = emptyList(),
+                devicePreparingEvents = emptyList(),
+                deviceConnectedEvents = listOf(
+                    DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
+                ),
+                testEvents = listOf(
+                    createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace, false),
+                    createTestEvent(device, "test1", TestStatus.PASSED, final = true)
+                )
+            )
+            val configuration = getConfiguration()
+            println(configuration.outputDir)
+            on("Marathon JUnit Report") {
+                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val junitReport = JUnitReporter(jUnitWriter)
+                junitReport.generate(report)
+                it("should generate correct report") {
+                    File(configuration.outputDir.absolutePath + "/tests/myPool/xxyyzz/marathon_junit_report.xml")
+                        .shouldBeEqualToAsXML(File(javaClass.getResource("/output/tests/myPool/xxyyzz/marathon_junit_report_failed_to_passed_test.xml").file))
+                }
+            }
+        }
+        given("an ExecutionReport with multiple execution of the same test from PASSED to FAILURE") {
+            val device = getDevice()
+            val stackTrace = "Exception in thread \"main\" java.lang.RuntimeException: A test exception\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)\n" +
+                "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
+                "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
+            val report = ExecutionReport(
+                deviceProviderPreparingEvent = emptyList(),
+                devicePreparingEvents = emptyList(),
+                deviceConnectedEvents = listOf(
+                    DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
+                ),
+                testEvents = listOf(
+                    createTestEvent(device, "test1", TestStatus.PASSED, final = false),
+                    createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace)
+                )
+            )
+            val configuration = getConfiguration()
+            println(configuration.outputDir)
+            on("Marathon JUnit Report") {
+                val jUnitWriter = JUnitWriter(FileManager(configuration.outputDir))
+                val junitReport = JUnitReporter(jUnitWriter)
+                junitReport.generate(report)
+                it("should generate correct report") {
+                    File(configuration.outputDir.absolutePath + "/tests/myPool/xxyyzz/marathon_junit_report.xml")
+                        .shouldBeEqualToAsXML(File(javaClass.getResource("/output/tests/myPool/xxyyzz/marathon_junit_report_passed_to_failed_test.xml").file))
+                }
+            }
+        }
+    })
+

--- a/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests.xml
+++ b/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="common" tests="3" failures="3" errors="0" skipped="0" time="35.757" timestamp="2018-11-08T11:19:01">
+  <properties></properties>
+  <testcase classname="com.example" name="test1" time="11.919">
+    <failure></failure>
+  </testcase>
+  <testcase classname="com.example" name="test2" time="11.919">
+    <failure></failure>
+  </testcase>
+  <testcase classname="com.example" name="test3" time="11.919">
+    <failure></failure>
+  </testcase>
+</testsuite>

--- a/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests_with_stacktrace.xml
+++ b/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_tests_with_stacktrace.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="common" tests="4" failures="2" errors="0" skipped="2" time="47.676" timestamp="2018-11-08T11:19:01">
+  <properties></properties>
+  <testcase classname="com.example" name="test1" time="11.919">
+    <failure>
+      <![CDATA[Exception in thread "main" java.lang.RuntimeException: A test exception
+  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)
+  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)
+  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)]]>
+    </failure>
+  </testcase>
+  <testcase classname="com.example" name="test2" time="11.919">
+    <skipped></skipped>
+  </testcase>
+  <testcase classname="com.example" name="test2" time="11.919">
+    <failure></failure>
+  </testcase>
+  <testcase classname="com.example" name="test3" time="11.919">
+    <skipped>
+      <![CDATA[Exception in thread "main" java.lang.RuntimeException: A test exception
+  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)
+  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)
+  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)]]>
+    </skipped>
+  </testcase>
+</testsuite>

--- a/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_to_passed_test.xml
+++ b/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_failed_to_passed_test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="common" tests="1" failures="0" errors="0" skipped="0" time="11.919" timestamp="2018-11-08T11:19:01">
+  <properties></properties>
+  <testcase classname="com.example" name="test1" time="11.919"></testcase>
+</testsuite>

--- a/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_passed_tests.xml
+++ b/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_passed_tests.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="common" tests="3" failures="0" errors="0" skipped="0" time="35.757" timestamp="2018-11-08T11:19:01">
+  <properties></properties>
+  <testcase classname="com.example" name="test1" time="11.919"></testcase>
+  <testcase classname="com.example" name="test2" time="11.919"></testcase>
+  <testcase classname="com.example" name="test3" time="11.919"></testcase>
+</testsuite>

--- a/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_passed_to_failed_test.xml
+++ b/core/src/test/resources/output/tests/myPool/xxyyzz/marathon_junit_report_passed_to_failed_test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="common" tests="1" failures="1" errors="0" skipped="0" time="11.919" timestamp="2018-11-08T11:19:01">
+  <properties></properties>
+  <testcase classname="com.example" name="test1" time="11.919">
+    <failure>
+      <![CDATA[Exception in thread "main" java.lang.RuntimeException: A test exception
+  at com.example.stacktrace.StackTraceExample.methodB(StackTraceExample.java:13)
+  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)
+  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)]]>
+    </failure>
+  </testcase>
+</testsuite>

--- a/vendor/vendor-test/build.gradle.kts
+++ b/vendor/vendor-test/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(Libraries.kotlinLogging)
     implementation(Libraries.kotlinReflect)
     implementation(TestLibraries.jsonAssert)
+    implementation(TestLibraries.xmlUnit)
     implementation(TestLibraries.spekAPI)
     implementation(TestLibraries.kluent)
     implementation(TestLibraries.mockitoKotlin)

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/assert/FileExtensions.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/assert/FileExtensions.kt
@@ -1,9 +1,16 @@
 package com.malinskiy.marathon.test.assert
 
+import org.hamcrest.MatcherAssert
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
+import org.xmlunit.builder.Input
+import org.xmlunit.matchers.CompareMatcher.isIdenticalTo
 import java.io.File
 
 fun File.shouldBeEqualToAsJson(expected: File) {
     JSONAssert.assertEquals(expected.readText(), readText(), JSONCompareMode.LENIENT)
+}
+
+fun File.shouldBeEqualToAsXML(expected: File) {
+    MatcherAssert.assertThat(this, isIdenticalTo(Input.fromFile(expected)).ignoreWhitespace())
 }


### PR DESCRIPTION
This PR enables marathon to create a single Junit Report per pool/ per device comprising of all of the tests executed in them.
Previously marathon was creating one XML report per test case.