### PR TITLE
Build does not fail though count sharding and Strict mode is true

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/di/Modules.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/di/Modules.kt
@@ -29,7 +29,7 @@ val coreModule = module {
     single<Gson> { Gson() }
     single<Clock> { Clock.systemDefaultZone() }
     single<Timer> { SystemTimer(get()) }
-    single<ProgressReporter> { ProgressReporter() }
+    single<ProgressReporter> { ProgressReporter(get()) }
     single<Marathon> { Marathon(get(), get(), get(), get(), get()) }
 }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
@@ -11,9 +11,8 @@ import kotlin.math.roundToInt
 
 const val HUNDRED_PERCENT_IN_FLOAT: Float = 100.0f
 
-class ProgressReporter {
+class ProgressReporter(private val configuration: Configuration) {
     private val reporters = ConcurrentHashMap<DevicePoolId, PoolProgressTracker>()
-    private lateinit var configuration: Configuration
 
     private inline fun <T> execute(poolId: DevicePoolId, f: (PoolProgressTracker) -> T): T {
         val reporter = reporters[poolId] ?: PoolProgressTracker(configuration)
@@ -51,10 +50,6 @@ class ProgressReporter {
         return reporters.isNotEmpty() && reporters.values.all {
             it.aggregateResult()
         }
-    }
-
-    fun init(configuration: Configuration){
-        this.configuration = configuration
     }
 
     fun totalTests(poolId: DevicePoolId, size: Int) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.execution.progress
 
 import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.progress.tracker.PoolProgressTracker
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.toTestName
@@ -12,9 +13,10 @@ const val HUNDRED_PERCENT_IN_FLOAT: Float = 100.0f
 
 class ProgressReporter {
     private val reporters = ConcurrentHashMap<DevicePoolId, PoolProgressTracker>()
+    private lateinit var configuration: Configuration
 
     private inline fun <T> execute(poolId: DevicePoolId, f: (PoolProgressTracker) -> T): T {
-        val reporter = reporters[poolId] ?: PoolProgressTracker()
+        val reporter = reporters[poolId] ?: PoolProgressTracker(configuration)
         val result = f(reporter)
         reporters[poolId] = reporter
         return result
@@ -49,6 +51,10 @@ class ProgressReporter {
         return reporters.isNotEmpty() && reporters.values.all {
             it.aggregateResult()
         }
+    }
+
+    fun init(configuration: Configuration){
+        this.configuration = configuration
     }
 
     fun totalTests(poolId: DevicePoolId, size: Int) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
@@ -26,7 +26,7 @@ class PoolProgressTracker(private val configuration: Configuration) {
             on<ProgressEvent.Failed> {
                 if (configuration.strictMode) {
                     transitionTo(ProgressTestState.Failed)
-                } else{
+                } else {
                     dontTransition()
                 }
             }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
@@ -26,7 +26,7 @@ class PoolProgressTracker(private val configuration: Configuration) {
             on<ProgressEvent.Failed> {
                 if (configuration.strictMode) {
                     transitionTo(ProgressTestState.Failed)
-                }else{
+                } else{
                     dontTransition()
                 }
             }
@@ -38,7 +38,7 @@ class PoolProgressTracker(private val configuration: Configuration) {
             on<ProgressEvent.Passed> {
                 if (configuration.strictMode) {
                     dontTransition()
-                }else {
+                } else {
                     transitionTo(ProgressTestState.Passed)
                 }
             }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
@@ -1,10 +1,11 @@
 package com.malinskiy.marathon.execution.progress.tracker
 
 import com.malinskiy.marathon.actor.StateMachine
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.test.Test
 import java.util.concurrent.atomic.AtomicInteger
 
-class PoolProgressTracker {
+class PoolProgressTracker(private val configuration: Configuration) {
 
     private val tests = mutableMapOf<Test, StateMachine<ProgressTestState, ProgressEvent, Any>>()
 
@@ -23,7 +24,11 @@ class PoolProgressTracker {
         }
         state<ProgressTestState.Passed> {
             on<ProgressEvent.Failed> {
-                dontTransition()
+                if (configuration.strictMode) {
+                    transitionTo(ProgressTestState.Failed)
+                }else{
+                    dontTransition()
+                }
             }
             on<ProgressEvent.Ignored> {
                 dontTransition()
@@ -31,8 +36,13 @@ class PoolProgressTracker {
         }
         state<ProgressTestState.Failed> {
             on<ProgressEvent.Passed> {
-                transitionTo(ProgressTestState.Passed)
+                if (configuration.strictMode) {
+                    dontTransition()
+                }else {
+                    transitionTo(ProgressTestState.Passed)
+                }
             }
+
         }
         state<ProgressTestState.Ignored> {
             on<ProgressEvent.Passed> {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -50,6 +50,7 @@ class QueueActor(
 
     init {
         queue.addAll(testShard.tests + testShard.flakyTests)
+        progressReporter.init(configuration)
         progressReporter.totalTests(poolId, queue.size)
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -50,7 +50,6 @@ class QueueActor(
 
     init {
         queue.addAll(testShard.tests + testShard.flakyTests)
-        progressReporter.init(configuration)
         progressReporter.totalTests(poolId, queue.size)
     }
 

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
@@ -17,7 +17,32 @@ import org.jetbrains.spek.api.dsl.it
 class ProgressReporterSpek : Spek(
     {
         describe("ProgressReporter") {
-            val reporter = ProgressReporter()
+            val reporter = ProgressReporter(Configuration(
+                name = "",
+                outputDir = File(""),
+                analyticsConfiguration = null,
+                poolingStrategy = null,
+                shardingStrategy = null,
+                sortingStrategy = null,
+                batchingStrategy = null,
+                flakinessStrategy = null,
+                retryStrategy = null,
+                filteringConfiguration = null,
+                ignoreFailures = null,
+                isCodeCoverageEnabled = null,
+                fallbackToScreenshots = null,
+                strictMode = null,
+                uncompletedTestRetryQuota = null,
+                testClassRegexes = null,
+                includeSerialRegexes = null,
+                excludeSerialRegexes = null,
+                testBatchTimeoutMillis = null,
+                testOutputTimeoutMillis = null,
+                debug = false,
+                screenRecordingPolicy = null,
+                vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
+                analyticsTracking = false
+            ))
             val deviceInfo = StubDevice().toDeviceInfo()
 
             it("should report proper progress for one pool") {
@@ -27,32 +52,6 @@ class ProgressReporterSpek : Spek(
                 val test2 = Test("com.example", "SimpleTest", "method2", emptyList())
                 val test3 = Test("com.example", "SimpleTest", "method3", emptyList())
 
-                reporter.init(Configuration(
-                    name = "",
-                    outputDir = File(""),
-                    analyticsConfiguration = null,
-                    poolingStrategy = null,
-                    shardingStrategy = null,
-                    sortingStrategy = null,
-                    batchingStrategy = null,
-                    flakinessStrategy = null,
-                    retryStrategy = null,
-                    filteringConfiguration = null,
-                    ignoreFailures = null,
-                    isCodeCoverageEnabled = null,
-                    fallbackToScreenshots = null,
-                    strictMode = null,
-                    uncompletedTestRetryQuota = null,
-                    testClassRegexes = null,
-                    includeSerialRegexes = null,
-                    excludeSerialRegexes = null,
-                    testBatchTimeoutMillis = null,
-                    testOutputTimeoutMillis = null,
-                    debug = false,
-                    screenRecordingPolicy = null,
-                    vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
-                    analyticsTracking = false
-                ))
                 reporter.totalTests(poolId, 3)
                 reporter.progress().shouldEqualTo(.0f)
 

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
@@ -2,8 +2,13 @@ package com.malinskiy.marathon.execution.progress
 
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.device.toDeviceInfo
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.test.Mocks
 import com.malinskiy.marathon.test.StubDevice
+import com.malinskiy.marathon.test.StubDeviceProvider
 import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.TestVendorConfiguration
+import java.io.File
 import org.amshove.kluent.shouldEqualTo
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -22,6 +27,32 @@ class ProgressReporterSpek : Spek(
                 val test2 = Test("com.example", "SimpleTest", "method2", emptyList())
                 val test3 = Test("com.example", "SimpleTest", "method3", emptyList())
 
+                reporter.init(Configuration(
+                    name = "",
+                    outputDir = File(""),
+                    analyticsConfiguration = null,
+                    poolingStrategy = null,
+                    shardingStrategy = null,
+                    sortingStrategy = null,
+                    batchingStrategy = null,
+                    flakinessStrategy = null,
+                    retryStrategy = null,
+                    filteringConfiguration = null,
+                    ignoreFailures = null,
+                    isCodeCoverageEnabled = null,
+                    fallbackToScreenshots = null,
+                    strictMode = null,
+                    uncompletedTestRetryQuota = null,
+                    testClassRegexes = null,
+                    includeSerialRegexes = null,
+                    excludeSerialRegexes = null,
+                    testBatchTimeoutMillis = null,
+                    testOutputTimeoutMillis = null,
+                    debug = false,
+                    screenRecordingPolicy = null,
+                    vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
+                    analyticsTracking = false
+                ))
                 reporter.totalTests(poolId, 3)
                 reporter.progress().shouldEqualTo(.0f)
 

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerSpek.kt
@@ -1,0 +1,88 @@
+package com.malinskiy.marathon.execution.progress.tracker
+
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.test.Mocks
+import com.malinskiy.marathon.test.StubDeviceProvider
+import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.TestVendorConfiguration
+import org.amshove.kluent.shouldEqualTo
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import java.io.File
+
+class PoolProgressTrackerSpek : Spek(
+    {
+        val test = Test(
+            pkg = "com.malinskiy.marathon",
+            clazz = "SomeTest",
+            method = "someMethod",
+            metaProperties = emptyList()
+        )
+
+        fun createConfiguration(strictMode: Boolean): Configuration {
+            return Configuration(
+                name = "",
+                outputDir = File(""),
+                analyticsConfiguration = null,
+                poolingStrategy = null,
+                shardingStrategy = null,
+                sortingStrategy = null,
+                batchingStrategy = null,
+                flakinessStrategy = null,
+                retryStrategy = null,
+                filteringConfiguration = null,
+                ignoreFailures = null,
+                isCodeCoverageEnabled = null,
+                fallbackToScreenshots = null,
+                strictMode = strictMode,
+                uncompletedTestRetryQuota = null,
+                testClassRegexes = null,
+                includeSerialRegexes = null,
+                excludeSerialRegexes = null,
+                testBatchTimeoutMillis = null,
+                testOutputTimeoutMillis = null,
+                debug = false,
+                screenRecordingPolicy = null,
+                vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
+                analyticsTracking = false
+            )
+        }
+
+        given("Configuration strictMode false") {
+            val unit = PoolProgressTracker(createConfiguration(strictMode = false))
+            on("Test started, passed and then failed") {
+                unit.testStarted(test)
+                unit.testPassed(test)
+                unit.testFailed(test)
+                it("Produces true") {
+                    unit.aggregateResult().shouldEqualTo(true)
+                }
+            }
+            on("Test passed again") {
+                unit.testPassed(test)
+                it("Produces true") {
+                    unit.aggregateResult().shouldEqualTo(true)
+                }
+            }
+        }
+
+        given("Configuration strictMode true") {
+            val unit = PoolProgressTracker(createConfiguration(strictMode = true))
+            on("Test started, passed and then failed") {
+                unit.testStarted(test)
+                unit.testPassed(test)
+                unit.testFailed(test)
+                it("Produces false") {
+                    unit.aggregateResult().shouldEqualTo(false)
+                }
+            }
+            on("Test passed again") {
+                unit.testPassed(test)
+                it("Produces false") {
+                    unit.aggregateResult().shouldEqualTo(false)
+                }
+            }
+        }
+    })


### PR DESCRIPTION
Pass configuration into PoolProgressTracker so that when strict mode is true, transition from pass to fail can happen. This is raised for issue https://github.com/Malinskiy/marathon/issues/331