### PR TITLE
Make reports independent of attachment naming

### DIFF
--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturer.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturer.kt
@@ -2,18 +2,14 @@ package com.malinskiy.marathon.android.executor.listeners.screenshot
 
 import com.malinskiy.marathon.android.AndroidDevice
 import com.malinskiy.marathon.android.exception.CommandRejectedException
-import com.malinskiy.marathon.device.DevicePoolId
-import com.malinskiy.marathon.device.toDeviceInfo
-import com.malinskiy.marathon.io.FileManager
-import com.malinskiy.marathon.io.FileType
 import com.malinskiy.marathon.log.MarathonLogging
-import com.malinskiy.marathon.test.Test
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.imgscalr.Scalr
 import java.awt.image.BufferedImage.TYPE_INT_ARGB
 import java.awt.image.RenderedImage
+import java.io.File
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -22,15 +18,14 @@ import kotlin.system.measureTimeMillis
 
 
 class ScreenCapturer(
-    val device: AndroidDevice,
-    private val poolId: DevicePoolId,
-    private val fileManager: FileManager,
-    val test: Test
+    private val device: AndroidDevice,
+    private val gifFile: File
 ) {
 
     suspend fun start() = coroutineScope {
-        val outputStream = FileImageOutputStream(fileManager.createFile(FileType.SCREENSHOT, poolId, device.toDeviceInfo(), test))
+        val outputStream = FileImageOutputStream(gifFile)
         val writer = GifSequenceWriter(outputStream, TYPE_INT_ARGB, DELAY, true)
+
         var targetOrientation = UNDEFINED
         while (isActive) {
             val capturingTimeMillis = measureTimeMillis {
@@ -48,6 +43,7 @@ class ScreenCapturer(
             }
             delay(sleepTimeMillis)
         }
+
         writer.close()
         outputStream.close()
     }


### PR DESCRIPTION
I want to make reports independent of attachment names.
This add the ability to change the name of the attachment without breaking the reports.

I found two weak points:

1. **HtmlSummaryReporter**. It has already been refactored more than once, so I suggest a different solution. Instead of a hardcore path to the files and checking for their existence, just _take the attachments_.
2. **ScreenCapturerTestRunListener**. This only works because the same hardoced names are passed to the constructor of `File`. It is much more reliable to _pass a File_ to the `ScreenCapturer` where need to write a GIF.