### PR TITLE
Update AGP to 3.6.2 and FIX issues with deprecated methods

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
     val bugsnag = "3.6.1"
 
     val junitGradle = "1.0.0"
-    val androidGradleVersion = "3.3.0"
+    val androidGradleVersion = "3.6.1"
 
     val junit5 = "5.6.0"
     val kluent = "1.40"

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/extensions/BaseVariant.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/extensions/BaseVariant.kt
@@ -33,8 +33,8 @@ private fun extractApplication3_3_plus(output: BaseVariant): File? {
     return applicationProvider?.let {
         val apppackageAndroidArtifact = applicationProvider.get()
         assert(apppackageAndroidArtifact.apkNames.size == 1)
-        File(apppackageAndroidArtifact.outputDirectory, apppackageAndroidArtifact.apkNames.first())
-    } ?: null
+        File(apppackageAndroidArtifact.outputDirectory.asFile.get(), apppackageAndroidArtifact.apkNames.first())
+    }
 }
 
 @Suppress("DEPRECATION")
@@ -42,7 +42,7 @@ private fun extractApplicationBefore3_3(output: BaseVariant): File? {
     val variantOutput = output.outputs.first()
     return when (variantOutput) {
         is ApkVariantOutput -> {
-            File(variantOutput.getPackageApplication().outputDirectory.path, variantOutput.outputFileName)
+            File(variantOutput.packageApplication.outputDirectory.asFile.get(), variantOutput.outputFileName)
         }
         is LibraryVariantOutput -> {
             null

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/extensions/TestVariant.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/extensions/TestVariant.kt
@@ -24,7 +24,7 @@ private fun extractTestApplicationBefore3_3(variant: TestVariant): File {
     return File(
         when (output) {
             is ApkVariantOutput -> {
-                File(variant.packageApplication.outputDirectory.path, output.outputFileName).path
+                File(variant.packageApplication.outputDirectory.asFile.get(), output.outputFileName).path
             }
             is LibraryVariantOutput -> {
                 output.outputFile.path
@@ -53,7 +53,7 @@ private fun extractTestApplication3_3_plus(output: TestVariant): File {
     return when (testPackageAndroidArtifact) {
         is PackageAndroidArtifact -> {
             assert(testPackageAndroidArtifact.apkNames.size == 1)
-            File(testPackageAndroidArtifact.outputDirectory, testPackageAndroidArtifact.apkNames.first())
+            File(testPackageAndroidArtifact.outputDirectory.asFile.get(), testPackageAndroidArtifact.apkNames.first())
         }
         is Zip -> {
             testPackageAndroidArtifact.destFile

--- a/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
+++ b/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     val kotlin = "1.3.61"
 
-    val androidGradleVersion = "3.3.0"
+    val androidGradleVersion = "3.6.2"
 
     val kakao = "1.2.1"
     val espresso = "3.0.1"

--- a/sample/android-library/buildSrc/src/main/kotlin/Versions.kt
+++ b/sample/android-library/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     val kotlin = "1.3.61"
 
-    val androidGradleVersion = "3.3.0"
+    val androidGradleVersion = "3.6.2"
 
     val kakao = "1.2.1"
     val espresso = "3.0.1"


### PR DESCRIPTION
It fix this issue https://github.com/Malinskiy/marathon/issues/340

the only problem is that might not work for version of AGP > 3.3.0 so I didn't cleanup the support branch in the code.

Tell me if you see another solution