### PR TITLE
Add finally block to stop koin once started

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationTask
+import org.koin.core.context.stopKoin
 import java.io.File
 
 private val log = MarathonLogging.logger {}
@@ -86,15 +87,18 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
 
         UsageAnalytics.enable = cnf.analyticsTracking
         UsageAnalytics.USAGE_TRACKER.trackEvent(Event(TrackActionType.RunType, "gradle"))
+        try {
+            val application = marathonStartKoin(cnf)
+            val marathon: Marathon = application.koin.get()
 
-        val application = marathonStartKoin(cnf)
-        val marathon: Marathon = application.koin.get()
-
-        val success = marathon.run()
-        exceptionsTracker.end()
-        val shouldReportFailure = !cnf.ignoreFailures
-        if (!success && shouldReportFailure) {
-            throw GradleException("Tests failed! See ${cnf.outputDir}/html/index.html")
+            val success = marathon.run()
+            exceptionsTracker.end()
+            val shouldReportFailure = !cnf.ignoreFailures
+            if (!success && shouldReportFailure) {
+                throw GradleException("Tests failed! See ${cnf.outputDir}/html/index.html")
+            }
+        } finally {
+            stopKoin()
         }
     }
 

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
@@ -4,6 +4,7 @@ import com.android.ddmlib.AndroidDebugBridge
 import com.android.ddmlib.DdmPreferences
 import com.android.ddmlib.IDevice
 import com.android.ddmlib.TimeoutException
+import com.malinskiy.marathon.actor.safeSend
 import com.malinskiy.marathon.actor.unboundedChannel
 import com.malinskiy.marathon.analytics.internal.pub.Track
 import com.malinskiy.marathon.android.AndroidConfiguration
@@ -130,13 +131,13 @@ class DdmlibDeviceProvider(
 
             private fun notifyConnected(device: DdmlibAndroidDevice) {
                 launch {
-                    channel.send(DeviceConnected(device))
+                    channel.safeSend(DeviceConnected(device))
                 }
             }
 
             private fun notifyDisconnected(device: DdmlibAndroidDevice) {
                 launch {
-                    channel.send(DeviceDisconnected(device))
+                    channel.safeSend(DeviceDisconnected(device))
                 }
             }
         }


### PR DESCRIPTION
It should close this issue : https://github.com/Malinskiy/marathon/issues/333
The issue was if an exception occured in the GlobalScope and it's not catch then stopKoin() is never called and the only way to make it works again was to kill the gradle process.

So here I just add a finally block to stopKoin in any case, so we can restart marathon without killing the process