### PR TITLE
feat(bugsnag): improve analytics

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,7 @@ buildConfig {
     appName = project.name
     version = Versions.marathon
     buildConfigField("String", "BUGSNAG_TOKEN", System.getenv("BUGSNAG_TOKEN"))
+    buildConfigField("String", "RELEASE_MODE", Deployment.releaseMode)
 }
 
 dependencies {

--- a/core/src/main/kotlin/com/malinskiy/marathon/exceptions/BugsnagExceptionsReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/exceptions/BugsnagExceptionsReporter.kt
@@ -20,6 +20,22 @@ class BugsnagExceptionsReporter : ExceptionsReporter {
         bugsnag?.apply {
             setAppType(appType.value)
             setAppVersion(BuildConfig.VERSION)
+            /**
+             * This exception is bloating our events. Sample stacktrace usually includes:
+             *
+             * java.lang.ThreadDeath
+             * at java.lang.Thread.stop(Thread.java:853)
+             * at org.jetbrains.kotlin.daemon.client.KotlinCompilerClient.startDaemon(KotlinCompilerClient.kt:447)
+             * ...
+             */
+            setIgnoreClasses("java.lang.ThreadDeath")
+            setProjectPackages("com.malinskiy")
+            when (BuildConfig.RELEASE_MODE) {
+                "RELEASE" -> setReleaseStage("production")
+                "SNAPSHOT" -> setReleaseStage("development")
+                else -> setReleaseStage("development")
+            }
+            setNotifyReleaseStages("production", "development")
         }
     }
 


### PR DESCRIPTION
- Ignore ThreadDeath which has over 40k events now and throttles our ingestion
- set project package
- production/development separation