### PR TITLE
Update ddmlib to 27.0.0 to enable ANDROID_ADB_USER_MANAGED_MODE support and AGP 4.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     val kotlin = "1.3.61"
     val coroutines = "1.3.1"
 
-    val ddmlib = "26.3.0"
+    val ddmlib = "27.0.0"
     val adam = "0.0.8"
     val dexTestParser = "2.1.1"
     val kotlinLogging = "1.7.6"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -14,7 +14,7 @@ object Versions {
     val bugsnag = "3.6.1"
 
     val junitGradle = "1.0.0"
-    val androidGradleVersion = "3.6.1"
+    val androidGradleVersion = "4.0.0"
 
     val junit5 = "5.6.0"
     val kluent = "1.40"

--- a/sample/android-app/app/build.gradle.kts
+++ b/sample/android-app/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 }
 
 android {
-    buildToolsVersion("28.0.3")
-    compileSdkVersion(28)
+    buildToolsVersion("29.0.2")
+    compileSdkVersion(29)
 
     defaultConfig {
         minSdkVersion(16)
-        targetSdkVersion(27)
+        targetSdkVersion(29)
 
         applicationId = "com.example"
         versionCode = 1

--- a/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
+++ b/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     val kotlin = "1.3.61"
     val coroutines = "1.3.3"
 
-    val androidGradleVersion = "3.6.2"
+    val androidGradleVersion = "4.0.0"
 
     val kakao = "1.2.1"
     val espresso = "3.0.1"

--- a/sample/android-library/buildSrc/src/main/kotlin/Versions.kt
+++ b/sample/android-library/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     val kotlin = "1.3.61"
     val coroutines = "1.3.3"
 
-    val androidGradleVersion = "3.6.2"
+    val androidGradleVersion = "4.0.0"
 
     val kakao = "1.2.1"
     val espresso = "3.0.1"

--- a/sample/android-library/library/build.gradle.kts
+++ b/sample/android-library/library/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    buildToolsVersion("28.0.3")
-    compileSdkVersion(28)
+    buildToolsVersion("29.0.2")
+    compileSdkVersion(29)
 
     defaultConfig {
         minSdkVersion(16)
-        targetSdkVersion(27)
+        targetSdkVersion(29)
 
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
I'm running into an environment where the lifecycle of ADB need to be control outside the build to do that we need to update the DDMLIB to 27.0.0 that introduce a flag called sUserManagedAdbMode it's set through the env variable `export ANDROID_ADB_USER_MANAGED_MODE=true`

It will prevent the ADB server to be killed