### PR TITLE
Add configs for device initialization timeouts

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -3,6 +3,7 @@ package com.malinskiy.marathon.cli.args
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
+import com.malinskiy.marathon.android.DEFAULT_WAIT_FOR_DEVICES_TIMEOUT
 import com.malinskiy.marathon.android.ScreenRecordConfiguration
 import com.malinskiy.marathon.android.VendorType
 import com.malinskiy.marathon.android.adam.di.adamModule
@@ -24,7 +25,8 @@ data class FileAndroidConfiguration(
     @JsonProperty("adbInitTimeoutMillis") val adbInitTimeoutMillis: Int?,
     @JsonProperty("installOptions") val installOptions: String?,
     @JsonProperty("serialStrategy") val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
-    @JsonProperty("screenRecordConfiguration") val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration()
+    @JsonProperty("screenRecordConfiguration") val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration(),
+    @JsonProperty("waitForDevicesTimeoutMillis") val waitForDevicesTimeoutMillis: Long?
 ) : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -49,6 +51,7 @@ data class FileAndroidConfiguration(
             installOptions = installOptions ?: DEFAULT_INSTALL_OPTIONS,
             serialStrategy = serialStrategy,
             screenRecordConfiguration = screenRecordConfiguration,
+            waitForDevicesTimeoutMillis = waitForDevicesTimeoutMillis ?: DEFAULT_WAIT_FOR_DEVICES_TIMEOUT,
             implementationModules = implementationModules
         )
     }

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -42,5 +42,6 @@ data class FileConfiguration(
 
     var vendorConfiguration: FileVendorConfiguration?,
 
-    var analyticsTracking: Boolean?
+    var analyticsTracking: Boolean?,
+    var deviceInitializationTimeoutMillis: Long?
 )

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -65,7 +65,8 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             debug = config.debug,
             screenRecordingPolicy = config.screenRecordingPolicy,
             vendorConfiguration = vendorConfiguration as VendorConfiguration,
-            analyticsTracking = config.analyticsTracking
+            analyticsTracking = config.analyticsTracking,
+            deviceInitializationTimeoutMillis = config.deviceInitializationTimeoutMillis
         )
     }
 

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationTest.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfigurationTest.kt
@@ -1,5 +1,6 @@
 package com.malinskiy.marathon.cli.args
 
+import com.malinskiy.marathon.android.ScreenRecordConfiguration
 import com.malinskiy.marathon.android.VendorType
 import com.malinskiy.marathon.android.serial.SerialStrategy
 import com.malinskiy.marathon.exceptions.ConfigurationException
@@ -20,7 +21,9 @@ class FileAndroidConfigurationTest {
         null,
         null,
         null,
-        SerialStrategy.AUTOMATIC
+        SerialStrategy.AUTOMATIC,
+        ScreenRecordConfiguration(),
+        15000L
     )
 
     private val env: File = File.createTempFile("foo", "bar")

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactoryTest.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactoryTest.kt
@@ -155,6 +155,7 @@ class ConfigFactoryTest {
         configuration.debug shouldEqual true
         configuration.screenRecordingPolicy shouldEqual ScreenRecordingPolicy.ON_ANY
 
+        configuration.deviceInitializationTimeoutMillis shouldEqual 300_000
         configuration.vendorConfiguration shouldEqual AndroidConfiguration(
             File("/local/android"),
             File("kotlin-buildscript/build/outputs/apk/debug/kotlin-buildscript-debug.apk"),
@@ -171,7 +172,8 @@ class ConfigFactoryTest {
                 preferableRecorderType = DeviceFeature.SCREENSHOT,
                 videoConfiguration = VideoConfiguration(false, 1080, 1920, 2, 300),
                 screenshotConfiguration = ScreenshotConfiguration(false, 1080, 1920, 200)
-            )
+            ),
+            15000L
         )
     }
 

--- a/cli/src/test/resources/fixture/config/sample_1.yaml
+++ b/cli/src/test/resources/fixture/config/sample_1.yaml
@@ -64,6 +64,7 @@ testBatchTimeoutMillis: 20000
 testOutputTimeoutMillis: 30000
 debug: true
 screenRecordingPolicy: "ON_ANY"
+deviceInitializationTimeoutMillis: 300000
 vendorConfiguration:
   type: "Android"
   androidSdk: "/local/android"
@@ -88,3 +89,4 @@ vendorConfiguration:
       width: 1080
       height: 1920
       delayMs: 200
+  waitForDevicesTimeoutMillis: 15000

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -18,6 +18,7 @@ import java.io.File
 
 private const val DEFAULT_EXECUTION_TIMEOUT_MILLIS: Long = 900_000
 private const val DEFAULT_OUTPUT_TIMEOUT_MILLIS: Long = 60_000
+private const val DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS = 180_000L
 
 data class Configuration constructor(
     val name: String,
@@ -50,7 +51,8 @@ data class Configuration constructor(
 
     val vendorConfiguration: VendorConfiguration,
 
-    val analyticsTracking: Boolean
+    val analyticsTracking: Boolean,
+    val deviceInitializationTimeoutMillis: Long
 ) {
 
     constructor(
@@ -84,7 +86,8 @@ data class Configuration constructor(
 
         vendorConfiguration: VendorConfiguration,
 
-        analyticsTracking: Boolean?
+        analyticsTracking: Boolean?,
+        deviceInitializationTimeoutMillis: Long?
     ) :
 
             this(
@@ -111,7 +114,8 @@ data class Configuration constructor(
                 debug = debug ?: true,
                 screenRecordingPolicy = screenRecordingPolicy ?: ScreenRecordingPolicy.ON_FAILURE,
                 vendorConfiguration = vendorConfiguration,
-                analyticsTracking = analyticsTracking ?: false
+                analyticsTracking = analyticsTracking ?: false,
+                deviceInitializationTimeoutMillis = deviceInitializationTimeoutMillis ?: DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS
             )
 
     fun toMap() =
@@ -137,6 +141,7 @@ data class Configuration constructor(
             "testOutputTimeoutMillis" to testOutputTimeoutMillis.toString(),
             "debug" to debug.toString(),
             "screenRecordingPolicy" to screenRecordingPolicy.toString(),
-            "vendorConfiguration" to vendorConfiguration.toString()
+            "vendorConfiguration" to vendorConfiguration.toString(),
+            "deviceInitializationTimeoutMillis" to deviceInitializationTimeoutMillis.toString()
         )
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Scheduler.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Scheduler.kt
@@ -109,7 +109,7 @@ class Scheduler(
         }
         pools[poolId]?.send(AddDevice(device)) ?: logger.debug {
             "not sending the AddDevice event " +
-                    "to device pool for ${device.serialNumber}"
+                "to device pool for ${device.serialNumber}"
         }
         track.deviceConnected(poolId, device.toDeviceInfo())
     }

--- a/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactoryTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/analytics/metrics/MetricsProviderFactoryTest.kt
@@ -44,7 +44,8 @@ class MetricsProviderFactoryTest {
                 override fun deviceProvider(): DeviceProvider? = null
                 override fun logConfigurator(): MarathonLogConfigurator? = null
             },
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
         val factory = MetricsProviderFactory(configuration)
         val metricsProvider = factory.create()
@@ -88,7 +89,8 @@ class MetricsProviderFactoryTest {
                 override fun deviceProvider(): DeviceProvider? = null
                 override fun logConfigurator(): MarathonLogConfigurator? = null
             },
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
         val factory = MetricsProviderFactory(configuration)
         val metricsProvider = factory.create()

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
@@ -38,7 +38,8 @@ class ProgressReporterTest {
             debug = false,
             screenRecordingPolicy = null,
             vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
     )
     private val deviceInfo = StubDevice().toDeviceInfo()

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
@@ -42,7 +42,8 @@ class PoolProgressTrackerTest {
             debug = false,
             screenRecordingPolicy = null,
             vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
     }
 

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorTest.kt
@@ -284,5 +284,6 @@ private val DEFAULT_CONFIGURATION = Configuration(
         testParser = mock(),
         deviceProvider = mock()
     ),
-    analyticsTracking = false
+    analyticsTracking = false,
+    deviceInitializationTimeoutMillis = null
 )

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -53,7 +53,8 @@ class TestResultReporterTest {
         debug = false,
         screenRecordingPolicy = null,
         vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
     private val strictConfig = defaultConfig.copy(strictMode = true)
     val test = generateTest()

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
@@ -52,7 +52,8 @@ class ExecutionReportTest {
             override fun deviceProvider(): DeviceProvider? = null
             override fun logConfigurator(): MarathonLogConfigurator? = null
         },
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
 
     private val reportWithoutRetries: ExecutionReport by lazy {

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
@@ -211,7 +211,8 @@ fun getConfiguration() =
             override fun deviceProvider(): DeviceProvider? = null
             override fun logConfigurator(): MarathonLogConfigurator? = null
         },
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
 
 fun getDevice() =

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonExtension.kt
@@ -50,6 +50,9 @@ open class MarathonExtension(project: Project) {
 
     var analyticsTracking: Boolean = false
 
+    var deviceInitializationTimeoutMillis: Long? = null
+    var waitForDevicesTimeoutMillis : Long? = null
+
     //Android specific for now
     var autoGrantPermission: Boolean? = null
     var instrumentationArgs: MutableMap<String, String> = mutableMapOf()

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonRunTask.kt
@@ -6,6 +6,7 @@ import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.DEFAULT_APPLICATION_PM_CLEAR
 import com.malinskiy.marathon.android.DEFAULT_AUTO_GRANT_PERMISSION
 import com.malinskiy.marathon.android.DEFAULT_INSTALL_OPTIONS
+import com.malinskiy.marathon.android.DEFAULT_WAIT_FOR_DEVICES_TIMEOUT
 import com.malinskiy.marathon.android.ScreenRecordConfiguration
 import com.malinskiy.marathon.android.VendorType
 import com.malinskiy.marathon.android.adam.di.adamModule
@@ -79,7 +80,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
             extensionConfig.debug,
             extensionConfig.screenRecordingPolicy,
             vendorConfiguration,
-            extensionConfig.analyticsTracking
+            extensionConfig.analyticsTracking,
+            extensionConfig.deviceInitializationTimeoutMillis
         )
 
         val androidConfiguration = cnf.vendorConfiguration as? AndroidConfiguration
@@ -118,6 +120,7 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
         val installOptions = extension.installOptions ?: DEFAULT_INSTALL_OPTIONS
         val screenRecordConfiguration = extension.screenRecordConfiguration ?: ScreenRecordConfiguration()
         val serialStrategy = extension.serialStrategy ?: SerialStrategy.AUTOMATIC
+        val waitForDevicesTimeoutMillis = extension.waitForDevicesTimeoutMillis ?: DEFAULT_WAIT_FOR_DEVICES_TIMEOUT
 
         val implementationModules = when (extension.vendor ?: VendorType.DDMLIB) {
             VendorType.DDMLIB -> listOf(ddmlibModule)
@@ -136,7 +139,8 @@ open class MarathonRunTask : DefaultTask(), VerificationTask {
             adbInitTimeoutMillis = adbInitTimeout,
             installOptions = installOptions,
             screenRecordConfiguration = screenRecordConfiguration,
-            serialStrategy = serialStrategy
+            serialStrategy = serialStrategy,
+            waitForDevicesTimeoutMillis = waitForDevicesTimeoutMillis
         )
     }
 

--- a/sample/android-app/Marathonfile
+++ b/sample/android-app/Marathonfile
@@ -15,3 +15,5 @@ vendorConfiguration:
   applicationPmClear: true
   testApplicationPmClear: true
   vendor: ADAM
+  waitForDevicesTimeoutMillis: 60000
+deviceInitializationTimeoutMillis: 180000

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
@@ -13,6 +13,7 @@ import com.malinskiy.marathon.android.AndroidConfiguration
 import com.malinskiy.marathon.android.exception.AdbStartException
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.exceptions.NoDevicesException
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.time.Timer
 import com.malinskiy.marathon.vendor.VendorConfiguration
@@ -27,10 +28,10 @@ import java.net.ConnectException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 
-private const val DEFAULT_WAIT_FOR_DEVICES_TIMEOUT = 30000L
 private const val DEFAULT_WAIT_FOR_DEVICES_SLEEP_TIME = 500L
 
 class AdamDeviceProvider(
+    configuration: Configuration,
     private val track: Track,
     private val timer: Timer
 ) : DeviceProvider, CoroutineScope {
@@ -46,7 +47,7 @@ class AdamDeviceProvider(
         newFixedThreadPoolContext(4, "AdbIOThreadPool")
     }
 
-    override val deviceInitializationTimeoutMillis: Long = 180_000
+    override val deviceInitializationTimeoutMillis: Long = configuration.deviceInitializationTimeoutMillis
 
     private lateinit var client: AndroidDebugBridgeClient
     private lateinit var deviceEventsChannel: ReceiveChannel<List<Device>>
@@ -71,7 +72,7 @@ class AdamDeviceProvider(
             printAdbServerVersion()
         }
 
-        withTimeoutOrNull(DEFAULT_WAIT_FOR_DEVICES_TIMEOUT) {
+        withTimeoutOrNull(vendorConfiguration.waitForDevicesTimeoutMillis) {
             while (client.execute(ListDevicesRequest()).isEmpty()) {
                 delay(DEFAULT_WAIT_FOR_DEVICES_SLEEP_TIME)
             }

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/di/Modules.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/di/Modules.kt
@@ -5,5 +5,5 @@ import com.malinskiy.marathon.device.DeviceProvider
 import org.koin.dsl.module
 
 val adamModule = module {
-    single<DeviceProvider?> { AdamDeviceProvider(get(), get()) }
+    single<DeviceProvider?> { AdamDeviceProvider(get(), get(), get()) }
 }

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/AndroidConfiguration.kt
@@ -17,6 +17,7 @@ const val DEFAULT_AUTO_GRANT_PERMISSION = false
 const val DEFAULT_APPLICATION_PM_CLEAR = false
 const val DEFAULT_TEST_APPLICATION_PM_CLEAR = false
 const val DEFAULT_INSTALL_OPTIONS = ""
+const val DEFAULT_WAIT_FOR_DEVICES_TIMEOUT = 30000L
 
 data class AndroidConfiguration(
     val androidSdk: File,
@@ -30,8 +31,8 @@ data class AndroidConfiguration(
     val adbInitTimeoutMillis: Int = defaultInitTimeoutMillis,
     val installOptions: String = DEFAULT_INSTALL_OPTIONS,
     val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
-    val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration()
-
+    val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration(),
+    val waitForDevicesTimeoutMillis: Long = DEFAULT_WAIT_FOR_DEVICES_TIMEOUT
 ) : VendorConfiguration, KoinComponent {
 
     private val koinModules = listOf(androidModule) + implementationModules

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserTest.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/AndroidTestParserTest.kt
@@ -39,7 +39,8 @@ class AndroidTestParserTest {
             testApplicationOutput = apkFile,
             implementationModules = emptyList()
         ),
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
 
     @Test

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/di/Modules.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/di/Modules.kt
@@ -3,5 +3,5 @@ import com.malinskiy.marathon.device.DeviceProvider
 import org.koin.dsl.module
 
 val ddmlibModule = module {
-    single<DeviceProvider?> { DdmlibDeviceProvider(get(), get()) }
+    single<DeviceProvider?> { DdmlibDeviceProvider(get(), get(), get()) }
 }

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceProviderTest.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceProviderTest.kt
@@ -2,16 +2,51 @@ package com.malinskiy.marathon.android
 
 import com.malinskiy.marathon.analytics.internal.pub.Track
 import com.malinskiy.marathon.android.ddmlib.DdmlibDeviceProvider
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.time.SystemTimer
+import ddmlibModule
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqual
 import org.junit.jupiter.api.Test
+import java.io.File
 import java.time.Clock
 
 class AndroidDeviceProviderTest {
     @Test
     fun `terminate should close the channel`() {
-        val provider = DdmlibDeviceProvider(Track(), SystemTimer(Clock.systemDefaultZone()))
+        val configuration = Configuration(
+            name = "",
+            outputDir = File(""),
+            analyticsConfiguration = null,
+            poolingStrategy = null,
+            shardingStrategy = null,
+            sortingStrategy = null,
+            batchingStrategy = null,
+            flakinessStrategy = null,
+            retryStrategy = null,
+            filteringConfiguration = null,
+            ignoreFailures = null,
+            isCodeCoverageEnabled = null,
+            fallbackToScreenshots = null,
+            strictMode = null,
+            uncompletedTestRetryQuota = null,
+            testClassRegexes = null,
+            includeSerialRegexes = null,
+            excludeSerialRegexes = null,
+            testBatchTimeoutMillis = null,
+            testOutputTimeoutMillis = null,
+            debug = null,
+            screenRecordingPolicy = null,
+            vendorConfiguration = AndroidConfiguration(
+                File(""),
+                applicationOutput = File(""),
+                testApplicationOutput = File(""),
+                implementationModules = listOf(ddmlibModule)
+            ),
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
+        )
+        val provider = DdmlibDeviceProvider(configuration, Track(), SystemTimer(Clock.systemDefaultZone()))
 
         runBlocking {
             provider.terminate()

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerTest.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerTest.kt
@@ -73,7 +73,8 @@ class AndroidDeviceTestRunnerTest {
                 testApplicationOutput = apkFile,
                 implementationModules = listOf(ddmlibModule)
             ),
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
         val ignoredTest =
             MarathonTest("ignored", "ignored", "ignored", listOf(MetaProperty("org.junit.Ignore")))
@@ -136,7 +137,8 @@ class AndroidDeviceTestRunnerTest {
                 testApplicationOutput = apkFile,
                 implementationModules = listOf(ddmlibModule)
             ),
-            analyticsTracking = false
+            analyticsTracking = false,
+            deviceInitializationTimeoutMillis = null
         )
         val ignoredTest =
             MarathonTest("ignored", "ignored", "ignored", listOf(MetaProperty("org.junit.Ignore")))

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDeviceProvider.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSDeviceProvider.kt
@@ -8,6 +8,7 @@ import com.google.gson.GsonBuilder
 import com.malinskiy.marathon.actor.unboundedChannel
 import com.malinskiy.marathon.analytics.internal.pub.Track
 import com.malinskiy.marathon.device.DeviceProvider
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.ios.device.LocalListSimulatorProvider
 import com.malinskiy.marathon.ios.device.SimulatorProvider
 import com.malinskiy.marathon.ios.simctl.model.SimctlDeviceList
@@ -22,6 +23,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 class IOSDeviceProvider(
+    configuration: Configuration,
     private val track: Track,
     private val timer: Timer
 ) : DeviceProvider, CoroutineScope {
@@ -34,7 +36,8 @@ class IOSDeviceProvider(
 
     private var simulatorProvider: SimulatorProvider? = null
 
-    override val deviceInitializationTimeoutMillis: Long = 300_000
+    override val deviceInitializationTimeoutMillis: Long = configuration.deviceInitializationTimeoutMillis
+
     override suspend fun initialize(vendorConfiguration: VendorConfiguration) {
         if (vendorConfiguration !is IOSConfiguration) {
             throw IllegalStateException("Invalid configuration $vendorConfiguration")

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/di/Modules.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/di/Modules.kt
@@ -7,6 +7,6 @@ import com.malinskiy.marathon.ios.IOSTestParser
 import org.koin.dsl.module
 
 val iosModule = module {
-    single<DeviceProvider?> { IOSDeviceProvider(get(), get()) }
+    single<DeviceProvider?> { IOSDeviceProvider(get(), get(), get()) }
     single<TestParser?> { IOSTestParser() }
 }

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerTest.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/DerivedDataManagerTest.kt
@@ -69,7 +69,8 @@ class DerivedDataManagerTest {
             debugSsh = false,
             alwaysEraseSimulators = true
         ),
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
 
     @BeforeEach

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSDeviceProviderTest.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSDeviceProviderTest.kt
@@ -1,14 +1,53 @@
 package com.malinskiy.marathon.ios
 
 import com.malinskiy.marathon.analytics.internal.pub.Track
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.time.SystemTimer
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqual
 import org.junit.jupiter.api.Test
+import java.io.File
 import java.time.Clock
 
 class IOSDeviceProviderTest {
-    private val provider = IOSDeviceProvider(Track(), SystemTimer(Clock.systemDefaultZone()))
+    private val configuration = Configuration(
+        name = "",
+        outputDir = File(""),
+        analyticsConfiguration = null,
+        poolingStrategy = null,
+        shardingStrategy = null,
+        sortingStrategy = null,
+        batchingStrategy = null,
+        flakinessStrategy = null,
+        retryStrategy = null,
+        filteringConfiguration = null,
+        ignoreFailures = null,
+        isCodeCoverageEnabled = null,
+        fallbackToScreenshots = null,
+        strictMode = null,
+        uncompletedTestRetryQuota = null,
+        testClassRegexes = null,
+        includeSerialRegexes = null,
+        excludeSerialRegexes = null,
+        testBatchTimeoutMillis = null,
+        testOutputTimeoutMillis = null,
+        debug = null,
+        screenRecordingPolicy = null,
+        vendorConfiguration = IOSConfiguration(
+            derivedDataDir = File(""),
+            xctestrunPath = File(""),
+            remoteUsername = "testuser",
+            remotePrivateKey = File("/home/fakekey"),
+            knownHostsPath = null,
+            remoteRsyncPath = "/remote/rsync",
+            sourceRoot = File(""),
+            debugSsh = false,
+            alwaysEraseSimulators = true
+        ),
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
+    )
+    private val provider = IOSDeviceProvider(configuration, Track(), SystemTimer(Clock.systemDefaultZone()))
 
     @Test
     fun `should close the channel`() {

--- a/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserTest.kt
+++ b/vendor/vendor-ios/src/test/kotlin/com/malinskiy/marathon/ios/IOSTestParserTest.kt
@@ -48,7 +48,8 @@ class IOSTestParserTest {
             debugSsh = false,
             alwaysEraseSimulators = true
         ),
-        analyticsTracking = false
+        analyticsTracking = false,
+        deviceInitializationTimeoutMillis = null
     )
 
     @Test

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/ConfigurationFactory.kt
@@ -41,6 +41,7 @@ class ConfigurationFactory {
     var testOutputTimeoutMillis = null
     var analyticsTracking = false
     var screenRecordingPolicy: ScreenRecordingPolicy? = null
+    var deviceInitializationTimeoutMillis: Long? = null
 
     fun tests(block: () -> List<Test>) {
         val testParser = vendorConfiguration.testParser()!!
@@ -77,6 +78,7 @@ class ConfigurationFactory {
             debug,
             screenRecordingPolicy,
             vendorConfiguration,
-            analyticsTracking
+            analyticsTracking,
+            deviceInitializationTimeoutMillis
         )
 }


### PR DESCRIPTION
Fix for #363.
I added two new configs.
Configuration: deviceInitializationTimeoutMillis
AndroidVendorConfiguration - waitForDevicesTimeoutMillis