### PR TITLE
Change order for SerialStrategy.AUTOMATIC

### DIFF
--- a/sample/android-app/Marathonfile
+++ b/sample/android-app/Marathonfile
@@ -9,7 +9,6 @@ vendorConfiguration:
   applicationApk: "app/build/outputs/apk/debug/app-debug.apk"
   testApplicationApk: "app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk"
   autoGrantPermission: true
-  serialStrategy: "DDMS"
   instrumentationArgs:
     debug: "false"
   applicationPmClear: true

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -109,9 +109,9 @@ abstract class BaseAndroidDevice(
         val result = when (serialStrategy) {
             SerialStrategy.AUTOMATIC -> {
                 marathonSerialProp.takeIf { it.isNotEmpty() }
+                    ?: serialNumber.takeIf { it.isNotEmpty() }
                     ?: serialProp.takeIf { it.isNotEmpty() }
                     ?: hostName.takeIf { it.isNotEmpty() }
-                    ?: serialNumber.takeIf { it.isNotEmpty() }
                     ?: UUID.randomUUID().toString()
             }
             SerialStrategy.MARATHON_PROPERTY -> marathonSerialProp


### PR DESCRIPTION
By default, marathonSerialProp is empty.
SerialProp, in my case, looks the same for all instances(EMULATOR29X2X1X0).
ADB serial number is the best option for default behavior