### PR TITLE
Upgrade test containers to latest RC

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -37,7 +37,7 @@ object Versions {
     val guava = "26.0-jre"
     val rsync4j = "3.1.2-12"
     val sshj = "0.26.0"
-    val testContainers = "1.9.1"
+    val testContainers = "1.15.0-rc2"
     val jupiterEngine = "5.1.0"
     val jansi = "1.17.1"
     val scalr = "4.2"


### PR DESCRIPTION
testcontainers 1.9.1 is not compatible with latest version of docker for mac. Execution always fails and this problem fixed in 1.15.0-rc2