### PR TITLE
feature(ci): publish distribution zip if present

### DIFF
--- a/.github/workflows/deploy-cli-snapshot-github.yml
+++ b/.github/workflows/deploy-cli-snapshot-github.yml
@@ -1,0 +1,22 @@
+name: deploy-cli-snapshot
+on:
+  push:
+    branches:
+      - develop
+    tags-ignore:
+      - '*'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: deploy-cli-snapshot-to-github
+        run: ./gradlew :cli:publishDefaultPublicationToGitHubRepository -PreleaseMode=SNAPSHOT
+        env:
+          GITHUB_MAVEN_USERNAME: ${{ secrets.GH_MAVEN_USERNAME }}
+          GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/deploy-cli-snapshot-github.yml
+++ b/.github/workflows/deploy-cli-snapshot-github.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: 1.8
       - name: deploy-cli-snapshot-to-github
-        run: ./gradlew :cli:publishDefaultPublicationToGitHubRepository -PreleaseMode=SNAPSHOT
+        run: ./gradlew :cli:publishDistZipPublicationToGitHubRepository -PreleaseMode=SNAPSHOT
         env:
           GITHUB_MAVEN_USERNAME: ${{ secrets.GH_MAVEN_USERNAME }}
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/buildSrc/src/main/kotlin/Deployment.kt
+++ b/buildSrc/src/main/kotlin/Deployment.kt
@@ -70,6 +70,8 @@ object Deployment {
                     from(project.components["java"])
                     artifact(sourcesJar)
                     artifact(javadocJar)
+
+                    project.tasks.findByName("distZip")?.let { distZip -> artifact(distZip) }
                 }
             }
             repositories {

--- a/buildSrc/src/main/kotlin/Deployment.kt
+++ b/buildSrc/src/main/kotlin/Deployment.kt
@@ -26,7 +26,7 @@ object Deployment {
         ?: "https://oss.sonatype.org/content/repositories/snapshots/"
     val releaseDeployUrl = System.getenv("SONATYPE_RELEASES_URL")
         ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-    val githubDeployUrl = "https://maven.pkg.github.com/Malinskiy"
+    val githubDeployUrl = "https://maven.pkg.github.com/Malinskiy/marathon"
 
     fun initialize(project: Project) {
         val releaseMode: String? by project


### PR DESCRIPTION
Sometimes our users need to use the latest snapshot CLI distribution. (#414)

In order to simplify this, we will start publishing a snapshot zip of the CLI.