### PR TITLE
ci(docs): add github action to push docs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,15 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: helaili/jekyll-action@2.0.4
+        env:
+          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}


### PR DESCRIPTION
default GitHub pages jekyll doesn't support any way of using plugins not approved by GitHub