### PR TITLE
feat(android): add support for Android 11 with allure enabled

### DIFF
--- a/docs/_posts/2018-11-19-android.md
+++ b/docs/_posts/2018-11-19-android.md
@@ -381,6 +381,16 @@ marathon {
 **resultsDirectory** is the path on the device where allure is outputting it's data. The default path for allure-kotlin is
  `/sdcard/allure-results`. Please refer to [allure's documentation][3] on the usage of allure.
  
+Starting with Android 11 your test application will be required MANAGE_EXTERNAL_STORAGE permission to write allure's output:
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+  ...
+</manifest>
+```
+Marathon will automatically grant this permission before executing tests if you're using allure integration
+ 
 Enabling this option effectively creates two allure reports for each test run:
 * one from the point of view of the marathon test runner
 * one from the point of view of on-device test execution

--- a/sample/android-app/app/build.gradle.kts
+++ b/sample/android-app/app/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     buildToolsVersion("29.0.2")
-    compileSdkVersion(29)
+    compileSdkVersion(30)
 
     defaultConfig {
         minSdkVersion(18)
-        targetSdkVersion(29)
+        targetSdkVersion(30)
 
         applicationId = "com.example"
         versionCode = 1

--- a/sample/android-app/app/src/debug/AndroidManifest.xml
+++ b/sample/android-app/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
@@ -144,7 +144,10 @@ class AndroidDeviceTestRunner(private val device: AdamAndroidDevice) {
             device.fileManager.removeRemotePath(androidConfiguration.allureConfiguration.resultsDirectory, recursive = true)
             device.fileManager.createRemoteDirectory(androidConfiguration.allureConfiguration.resultsDirectory)
             if (device.version.isGreaterOrEqualThan(30)) {
-                device.safeExecuteShellCommand("appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow")
+                val command = "appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow"
+                device.safeExecuteShellCommand(command)?.also {
+                    logger.debug { "Granted MANAGE_EXTERNAL_STORAGE to ${info.applicationPackage}: $it" }
+                }
             }
         }
     }

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
@@ -143,6 +143,9 @@ class AndroidDeviceTestRunner(private val device: AdamAndroidDevice) {
         if (androidConfiguration.allureConfiguration.enabled) {
             device.fileManager.removeRemotePath(androidConfiguration.allureConfiguration.resultsDirectory, recursive = true)
             device.fileManager.createRemoteDirectory(androidConfiguration.allureConfiguration.resultsDirectory)
+            if (device.version.isGreaterOrEqualThan(30)) {
+                device.safeExecuteShellCommand("appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow")
+            }
         }
     }
 

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -93,7 +93,10 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
             device.fileManager.removeRemotePath(androidConfiguration.allureConfiguration.resultsDirectory, recursive = true)
             device.fileManager.createRemoteDirectory(androidConfiguration.allureConfiguration.resultsDirectory)
             if (device.version.isGreaterOrEqualThan(30)) {
-                device.safeExecuteShellCommand("appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow")
+                val command = "appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow"
+                device.safeExecuteShellCommand(command)?.also {
+                    logger.debug { "Granted MANAGE_EXTERNAL_STORAGE to ${info.applicationPackage}: $it" }
+                }
             }
         }
     }

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -92,6 +92,9 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
         if (androidConfiguration.allureConfiguration.enabled) {
             device.fileManager.removeRemotePath(androidConfiguration.allureConfiguration.resultsDirectory, recursive = true)
             device.fileManager.createRemoteDirectory(androidConfiguration.allureConfiguration.resultsDirectory)
+            if (device.version.isGreaterOrEqualThan(30)) {
+                device.safeExecuteShellCommand("appops set --uid ${info.applicationPackage} MANAGE_EXTERNAL_STORAGE allow")
+            }
         }
     }
 


### PR DESCRIPTION
Each test execution requires the following to create allure test output:
- MANAGE_EXTERNAL_STORAGE permission in the manifest
- `appops set --uid PACKAGE_NAME MANAGE_EXTERNAL_STORAGE allow`

See https://developer.android.com/training/data-storage/manage-all-files#enable-manage-external-storage-for-testing