### PR TITLE
Android platform specific allow and block lists can be specified.

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileAndroidConfiguration.kt
@@ -29,7 +29,9 @@ data class FileAndroidConfiguration(
     @JsonProperty("serialStrategy") val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
     @JsonProperty("screenRecordConfiguration") val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration(),
     @JsonProperty("waitForDevicesTimeoutMillis") val waitForDevicesTimeoutMillis: Long?,
-    @JsonProperty("allureConfiguration") val allureConfiguration: AllureConfiguration?
+    @JsonProperty("allureConfiguration") val allureConfiguration: AllureConfiguration?,
+    @JsonProperty("allowList") val allowList: String = "",
+    @JsonProperty("blockList") val blockList: String = ""
 ) : FileVendorConfiguration {
 
     fun toAndroidConfiguration(environmentAndroidSdk: File?): AndroidConfiguration {
@@ -56,8 +58,9 @@ data class FileAndroidConfiguration(
             screenRecordConfiguration = screenRecordConfiguration,
             waitForDevicesTimeoutMillis = waitForDevicesTimeoutMillis ?: DEFAULT_WAIT_FOR_DEVICES_TIMEOUT,
             implementationModules = implementationModules,
-            allureConfiguration = allureConfiguration
-                ?: DEFAULT_ALLURE_CONFIGURATION
+            allureConfiguration = allureConfiguration ?: DEFAULT_ALLURE_CONFIGURATION,
+            allowList = allowList,
+            blockList = blockList
         )
     }
 }

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/configuration/AndroidConfiguration.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/configuration/AndroidConfiguration.kt
@@ -36,7 +36,9 @@ data class AndroidConfiguration(
     val serialStrategy: SerialStrategy = SerialStrategy.AUTOMATIC,
     val screenRecordConfiguration: ScreenRecordConfiguration = ScreenRecordConfiguration(),
     val waitForDevicesTimeoutMillis: Long = DEFAULT_WAIT_FOR_DEVICES_TIMEOUT,
-    val allureConfiguration: AllureConfiguration = DEFAULT_ALLURE_CONFIGURATION
+    val allureConfiguration: AllureConfiguration = DEFAULT_ALLURE_CONFIGURATION,
+    val allowList: String = "",
+    val blockList: String = ""
 ) : VendorConfiguration, KoinComponent {
 
     private val koinModules = listOf(androidModule) + implementationModules


### PR DESCRIPTION
At our organization, we use bare metal hosts at cloud as CI test runners. Each machine spawns many emulators. Since single machine can take only so many emulators, we encountered a scalability issue where we need to distribute our tests across multiple CI machines. Thanks to Marathon for being such a stable CI software. But, the default regex based test filter wouldn't really help overcome our scalability issue. I added a filter option only for Android where only designated tests can be run. The input format is a comma-separated list of fully qualified method name which well known on Android.