### PR TITLE
fix(ddmlib): force ddmlib termination in case devices are not available

### DIFF
--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
@@ -163,6 +163,7 @@ class DdmlibDeviceProvider(
             getDevicesCountdown -= sleepTime
         }
         if (!adb.hasInitialDeviceList() || !adb.hasDevices()) {
+            terminate()
             throw NoDevicesException("No devices found.")
         }
     }


### PR DESCRIPTION
we don't call systemExit() in case of success/ignoreFailures, hence the DdmlibDeviceProvider will hang the main thread if we don't close it

Fixes #437