### PR TITLE
fix(timeout): update test timeout defaults

### DIFF
--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactoryTest.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactoryTest.kt
@@ -227,8 +227,8 @@ class ConfigFactoryTest {
         configuration.ignoreFailures shouldEqual false
         configuration.isCodeCoverageEnabled shouldEqual false
         configuration.fallbackToScreenshots shouldEqual false
-        configuration.testBatchTimeoutMillis shouldEqual 900_000
-        configuration.testOutputTimeoutMillis shouldEqual 60_000
+        configuration.testBatchTimeoutMillis shouldEqual 1800_000
+        configuration.testOutputTimeoutMillis shouldEqual 300_000
         configuration.debug shouldEqual true
         configuration.screenRecordingPolicy shouldEqual ScreenRecordingPolicy.ON_FAILURE
         configuration.vendorConfiguration shouldEqual AndroidConfiguration(

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -16,8 +16,8 @@ import com.malinskiy.marathon.execution.strategy.impl.sorting.NoSortingStrategy
 import com.malinskiy.marathon.vendor.VendorConfiguration
 import java.io.File
 
-private const val DEFAULT_EXECUTION_TIMEOUT_MILLIS: Long = 900_000
-private const val DEFAULT_OUTPUT_TIMEOUT_MILLIS: Long = 60_000
+private const val DEFAULT_BATCH_EXECUTION_TIMEOUT_MILLIS: Long = 1800_000 //30 min
+private const val DEFAULT_OUTPUT_TIMEOUT_MILLIS: Long = 300_000 //5 min
 private const val DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS = 180_000L
 
 data class Configuration constructor(
@@ -109,7 +109,7 @@ data class Configuration constructor(
                 testClassRegexes = testClassRegexes ?: listOf(Regex("^((?!Abstract).)*Test[s]*$")),
                 includeSerialRegexes = includeSerialRegexes ?: emptyList(),
                 excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
-                testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
+                testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_BATCH_EXECUTION_TIMEOUT_MILLIS,
                 testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
                 debug = debug ?: true,
                 screenRecordingPolicy = screenRecordingPolicy ?: ScreenRecordingPolicy.ON_FAILURE,

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -1004,11 +1004,10 @@ marathon {
 {% endtabs %}
 
 ## Test output timeout
-This parameter specifies the behaviour for the underlying test executor to timeout if there is no output.
- By default, this is set to 60 seconds.
+This parameter specifies the behaviour for the underlying test executor to timeout if there is no output. By default, this is set to 5
+minutes.
 
-{% tabs test-output-timeout %}
-{% tab test-output-timeout Marathonfile %}
+{% tabs test-output-timeout %} {% tab test-output-timeout Marathonfile %}
 ```yaml
 testOutputTimeoutMillis: 30000
 ```
@@ -1030,11 +1029,11 @@ marathon {
 {% endtabs %}
 
 ## Test batch timeout
-This parameter specifies the behaviour for the underlying test executor to timeout if the batch execution exceeded some duration.
- By default, this is set to 15 minutes.
 
-{% tabs test-output-timeout %}
-{% tab test-output-timeout Marathonfile %}
+This parameter specifies the behaviour for the underlying test executor to timeout if the batch execution exceeded some duration. By
+default, this is set to 30 minutes.
+
+{% tabs test-output-timeout %} {% tab test-output-timeout Marathonfile %}
 ```yaml
 testBatchTimeoutMillis: 900000
 ```

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -126,7 +126,8 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice) {
         logger.debug { "tests = ${tests.toList()}" }
 
         runner.setRunName("TestRunName")
-        runner.setMaxTimeToOutputResponse(configuration.testOutputTimeoutMillis * testBatch.tests.size, TimeUnit.MILLISECONDS)
+        runner.setMaxTimeToOutputResponse(configuration.testOutputTimeoutMillis, TimeUnit.MILLISECONDS)
+        runner.setMaxTimeout(configuration.testBatchTimeoutMillis, TimeUnit.MILLISECONDS)
         runner.setClassNames(tests)
 
         androidConfiguration.instrumentationArgs.forEach { key, value ->


### PR DESCRIPTION
Single test 1m -> 5m
Batch 15m -> 30m

Notes:
* batch timeout previously was not picked up by ddmlib at all
* single test timeout was multiplied by test count in a batch in ddmlib. this might introduce timeout