### PR TITLE
Add failed test list to cli report

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
@@ -4,6 +4,7 @@ import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.execution.TestResult
 import com.malinskiy.marathon.execution.TestStatus
+import com.malinskiy.marathon.test.toTestName
 import java.time.Instant
 
 /**
@@ -31,16 +32,24 @@ data class ExecutionReport(
             .map { it.testResult }
             .filter { it.status != TestStatus.INCOMPLETE }
 
-        val passed = tests.count { it.status == TestStatus.PASSED }
-        val ignored = tests.count {
-            it.status == TestStatus.IGNORED
+        val passed = tests
+            .filter { it.status == TestStatus.PASSED }
+            .map { it.test.toTestName() }
+            .toSet()
+
+        val ignored = tests
+            .filter { it.status == TestStatus.IGNORED
                     || it.status == TestStatus.ASSUMPTION_FAILURE
-        }
-        val failed = tests.count {
-            it.status != TestStatus.PASSED
+            }.map { it.test.toTestName() }
+            .toSet()
+
+        val failed = tests
+            .filter { it.status != TestStatus.PASSED
                     && it.status != TestStatus.IGNORED
                     && it.status != TestStatus.ASSUMPTION_FAILURE
-        }
+             }.map { it.test.toTestName() }
+            .toSet()
+
         val duration = tests.map { it.durationMillis() }.sum()
 
         val rawTests = poolTestEvents

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
@@ -54,13 +54,19 @@ data class ExecutionReport(
 
         val rawTests = poolTestEvents
             .map { it.testResult }
-        val rawPassed = rawTests.count { it.status == TestStatus.PASSED }
-        val rawIgnored = rawTests.count {
-            it.status == TestStatus.IGNORED
+        val rawPassed = rawTests
+            .filter { it.status == TestStatus.PASSED }
+            .map { it.test.toTestName() }
+        val rawIgnored = rawTests
+            .filter { it.status == TestStatus.IGNORED
                 || it.status == TestStatus.ASSUMPTION_FAILURE
-        }
-        val rawFailed = rawTests.count { it.status == TestStatus.FAILURE }
-        val rawIncomplete = rawTests.count { it.status == TestStatus.INCOMPLETE }
+            }.map { it.test.toTestName() }
+        val rawFailed = rawTests
+            .filter { it.status == TestStatus.FAILURE }
+            .map { it.test.toTestName() }
+        val rawIncomplete = rawTests
+            .filter { it.status == TestStatus.INCOMPLETE }
+            .map { it.test.toTestName() }
         val rawDuration = rawTests
             //Incomplete tests mess up the calculations of time since their end time is 0 and duration is, hence, years
             //We filter here for unavailable time just to be safe

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
@@ -7,9 +7,9 @@ import com.malinskiy.marathon.execution.TestResult
 data class PoolSummary(
     val poolId: DevicePoolId,
     val tests: List<TestResult>,
-    val passed: Int,
-    val ignored: Int,
-    val failed: Int,
+    val passed: Set<String>,
+    val ignored: Set<String>,
+    val failed: Set<String>,
     val flaky: Int,
     val durationMillis: Long,
     val devices: List<DeviceInfo>,

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/PoolSummary.kt
@@ -13,9 +13,9 @@ data class PoolSummary(
     val flaky: Int,
     val durationMillis: Long,
     val devices: List<DeviceInfo>,
-    val rawPassed: Int,
-    val rawIgnored: Int,
-    val rawFailed: Int,
-    val rawIncomplete: Int,
+    val rawPassed: List<String>,
+    val rawIgnored: List<String>,
+    val rawFailed: List<String>,
+    val rawIncomplete: List<String>,
     val rawDurationMillis: Long
 )

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
@@ -208,9 +208,9 @@ class HtmlSummaryReporter(
     fun PoolSummary.toHtmlPoolSummary() = HtmlPoolSummary(
         id = poolId.name,
         tests = tests.map { it.toHtmlShortSuite() },
-        passedCount = passed,
-        failedCount = failed,
-        ignoredCount = ignored,
+        passedCount = passed.size,
+        failedCount = failed.size,
+        ignoredCount = ignored.size,
         durationMillis = durationMillis,
         devices = devices.map { it.toHtmlDevice() }
     )
@@ -218,9 +218,9 @@ class HtmlSummaryReporter(
 
     fun Summary.toHtmlIndex() = HtmlIndex(
         title = configuration.name,
-        totalFailed = pools.sumBy { it.failed },
-        totalIgnored = pools.sumBy { it.ignored },
-        totalPassed = pools.sumBy { it.passed },
+        totalFailed = pools.sumBy { it.failed.size },
+        totalIgnored = pools.sumBy { it.ignored.size },
+        totalPassed = pools.sumBy { it.passed.size },
         totalFlaky = pools.sumBy { it.flaky },
         totalDuration = totalDuration(pools),
         averageDuration = averageDuration(pools),

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
@@ -10,20 +10,24 @@ class StdoutReporter(private val timer: Timer) : Reporter {
         val summary = executionReport.summary
         if (summary.pools.isEmpty()) return
 
-        val cliReportBuilder = StringBuilder().appendln("Marathon run finished:")
+        val cliReportBuilder = StringBuilder().appendLine("Marathon run finished:")
         summary.pools.forEach {
-            cliReportBuilder.appendln(
-                "Device pool ${it.poolId.name}:\n" +
-                        "\t${it.passed} passed, ${it.failed} failed, ${it.ignored} ignored tests\n" +
-                        "\tFlakiness overhead: ${it.rawDurationMillis - it.durationMillis}ms\n" +
-                        "\tRaw: ${it.rawPassed} passed, ${it.rawFailed} failed, ${it.rawIgnored} ignored, ${it.rawIncomplete} incomplete tests"
-            )
+            cliReportBuilder.appendLine("Device pool ${it.poolId.name}:")
+            cliReportBuilder.appendLine("\t${it.passed.size} passed, ${it.failed.size} failed, ${it.ignored.size} ignored tests")
+
+            if(it.failed.isNotEmpty()){
+                cliReportBuilder.appendLine("\tFailed tests:")
+                it.failed.forEach { testName -> cliReportBuilder.appendLine("\t\t$testName") }
+            }
+
+            cliReportBuilder.appendLine("\tFlakiness overhead: ${it.rawDurationMillis - it.durationMillis}ms")
+            cliReportBuilder.appendLine("\tRaw: ${it.rawPassed} passed, ${it.rawFailed} failed, ${it.rawIgnored} ignored, ${it.rawIncomplete} incomplete tests")
         }
 
         val hours = TimeUnit.MILLISECONDS.toHours(timer.elapsedTimeMillis)
         val minutes = TimeUnit.MILLISECONDS.toMinutes(timer.elapsedTimeMillis) % 60
         val seconds = TimeUnit.MILLISECONDS.toSeconds(timer.elapsedTimeMillis) % 60
-        cliReportBuilder.appendln("Total time: ${hours}H ${minutes}m ${seconds}s")
+        cliReportBuilder.appendLine("Total time: ${hours}H ${minutes}m ${seconds}s")
 
         println(cliReportBuilder)
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/stdout/StdoutReporter.kt
@@ -32,7 +32,7 @@ class StdoutReporter(private val timer: Timer) : Reporter {
                     .toSortedMap()
                     .mapValues { it.value.size }
                     .forEach { (testName, count) ->
-                        cliReportBuilder.appendLine("\t\t$testName failed $count times")
+                        cliReportBuilder.appendLine("\t\t$testName failed $count time(s)")
                     }
             }
 
@@ -43,7 +43,7 @@ class StdoutReporter(private val timer: Timer) : Reporter {
                         .toSortedMap()
                         .mapValues { it.value.size }
                         .forEach { (testName, count) ->
-                            cliReportBuilder.appendLine("\t\t$testName incomplete $count times")
+                            cliReportBuilder.appendLine("\t\t$testName incomplete $count time(s)")
                         }
             }
         }


### PR DESCRIPTION
+ replace deprecated `appendln`

Final report
```
Device pool omni:
	22 passed, 2 failed, 0 ignored tests
	Failed tests:
		com.agoda.sample.DrawableListTest#matchDrawablesInListView
		com.agoda.sample.AutoCompleteTest#testContentItemsListView
	Flakiness overhead: 68065ms
	Raw: 22 passed, 4 failed, 0 ignored, 0 incomplete tests
	Failed tests:
		com.agoda.sample.DrawableListTest#matchDrawablesInListView failed 2 times
		com.agoda.sample.AutoCompleteTest#testContentItemsListView failed 2 times
Total time: 0H 4m 0s

```