### PR TITLE
Fix MarathonRunTask inputs #477

### DIFF
--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/MarathonPlugin.kt
@@ -7,7 +7,6 @@ import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariantOutput
 import com.android.build.gradle.api.TestVariant
 import com.malinskiy.marathon.config.AppType
-import com.malinskiy.marathon.exceptions.BugsnagExceptionsReporter
 import com.malinskiy.marathon.exceptions.ExceptionsReporter
 import com.malinskiy.marathon.exceptions.ExceptionsReporterFactory
 import com.malinskiy.marathon.extensions.executeGradleCompat
@@ -83,13 +82,13 @@ class MarathonPlugin : Plugin<Project> {
                     group = JavaBasePlugin.VERIFICATION_GROUP
                     description = "Runs instrumentation tests on all the connected devices for '${variant.name}' " +
                         "variation and generates a report with screenshots"
-                    flavorName = variant.name
-                    applicationVariant = variant.testedVariant
-                    testVariant = variant
-                    extensionConfig = config
-                    sdk = sdkDirectory
+                    flavorName.set(variant.name)
+                    applicationVariant.set(variant.testedVariant)
+                    testVariant.set(variant)
+                    marathonExtension.set(config)
+                    sdk.set(sdkDirectory)
                     outputs.upToDateWhen { false }
-                    exceptionsTracker = exceptionsReporter
+                    exceptionsTracker.set(exceptionsReporter)
                     executeGradleCompat(
                         exec = {
                             dependsOn(variant.testedVariant.assembleProvider, variant.assembleProvider)

--- a/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
+++ b/sample/android-app/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     val kotlin = "1.4.10"
     val coroutines = "1.3.9"
 
-    val androidGradleVersion = "4.0.0"
+    val androidGradleVersion = "4.1.0"
 
     val kakao = "2.4.0"
     val espresso = "3.3.0"


### PR DESCRIPTION
Replace @Input to @Internal for applicationVariant, testVariant, extensionConfig and exceptionsTracker.
Fix problem introduced in  #479
```
lateinit property cnf has not been initialized
```
```
Unable to store input properties for task ':app:marathonDebugAndroidTest'. Property 'extensionConfig' with value 'extension 'marathon'' cannot be serialized.
```
```
Unable to store input properties for task ':app:marathonDebugAndroidTest'. Property 'applicationVariant' with value 'com.android.build.gradle.internal.api.ApplicationVariantImpl_Decorated@5b9982d7' cannot be serialized.
```

```
Unable to store input properties for task ':app:marathonDebugAndroidTest'. Property 'testVariant' with value 'com.android.build.gradle.internal.api.TestVariantImpl_Decorated@3aefcb61' cannot be serialized.
```

```
Unable to store input properties for task ':app:marathonDebugAndroidTest'. Property 'exceptionsTracker' with value 'com.malinskiy.marathon.exceptions.BugsnagExceptionsReporter@1e79d8d9' cannot be serialized.
```
