### PR TITLE
[Gradle 7.0 migration] Fix gradle warnings

### DIFF
--- a/analytics/usage/build.gradle.kts
+++ b/analytics/usage/build.gradle.kts
@@ -16,6 +16,6 @@ tasks.withType<KotlinCompile> {
 dependencies {
     implementation(Analytics.googleAnalyticsWrapper)
     implementation(Libraries.kotlinStdLib)
-    testCompile(TestLibraries.kluent)
-    testCompile(TestLibraries.mockitoKotlin)
+    testImplementation(TestLibraries.kluent)
+    testImplementation(TestLibraries.mockitoKotlin)
 }

--- a/buildSrc/src/main/kotlin/Deployment.kt
+++ b/buildSrc/src/main/kotlin/Deployment.kt
@@ -57,11 +57,11 @@ object Deployment {
         val javaPlugin = project.the(JavaPluginConvention::class)
 
         val sourcesJar by project.tasks.creating(org.gradle.api.tasks.bundling.Jar::class) {
-            classifier = "sources"
+            archiveClassifier.set("sources")
             from(javaPlugin.sourceSets["main"].allSource)
         }
         val javadocJar by project.tasks.creating(org.gradle.api.tasks.bundling.Jar::class) {
-            classifier = "javadoc"
+            archiveClassifier.set("javadoc")
             from(javaPlugin.docsDir)
             dependsOn("javadoc")
         }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -23,14 +23,14 @@ val jvmOptions = listOf(
 ).filter { it.isNotBlank() }
 
 application {
-    mainClassName = "com.malinskiy.marathon.cli.ApplicationViewKt"
+    mainClass.set("com.malinskiy.marathon.cli.ApplicationViewKt")
     applicationName = "marathon"
     applicationDefaultJvmArgs = jvmOptions
 }
 
 distributions {
     getByName("main") {
-        baseName = "marathon"
+        distributionBaseName.set("marathon")
     }
 }
 
@@ -59,10 +59,10 @@ dependencies {
     implementation(Libraries.jacksonYaml)
     implementation(Libraries.jacksonJSR310)
     implementation(Libraries.apacheCommonsText)
-    testCompile(TestLibraries.kluent)
-    testCompile(TestLibraries.mockitoKotlin)
+    testImplementation(TestLibraries.kluent)
+    testImplementation(TestLibraries.mockitoKotlin)
     testImplementation(TestLibraries.junit5)
-    testRuntime(TestLibraries.jupiterEngine)
+    testRuntimeOnly(TestLibraries.jupiterEngine)
 }
 
 Deployment.initialize(project)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     testImplementation(TestLibraries.testContainersInflux)
     testImplementation(TestLibraries.mockitoKotlin)
     testImplementation(TestLibraries.koin)
-    testRuntime(TestLibraries.jupiterEngine)
+    testRuntimeOnly(TestLibraries.jupiterEngine)
 }
 
 tasks.named<JacocoReport>("jacocoTestReport").configure {

--- a/vendor/vendor-android/base/build.gradle.kts
+++ b/vendor/vendor-android/base/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     testImplementation(TestLibraries.kluent)
     testImplementation(TestLibraries.mockitoKotlin)
     testImplementation(TestLibraries.junit5)
-    testRuntime(TestLibraries.jupiterEngine)
+    testRuntimeOnly(TestLibraries.jupiterEngine)
     testImplementation(TestLibraries.koin)
 }
 

--- a/vendor/vendor-android/ddmlib/build.gradle.kts
+++ b/vendor/vendor-android/ddmlib/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     testImplementation(TestLibraries.mockitoKotlin)
     testImplementation(TestLibraries.koin)
     testImplementation(TestLibraries.junit5)
-    testRuntime(TestLibraries.jupiterEngine)
+    testRuntimeOnly(TestLibraries.jupiterEngine)
 }
 
 Deployment.initialize(project)

--- a/vendor/vendor-ios/build.gradle.kts
+++ b/vendor/vendor-ios/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(TestLibraries.mockitoKotlin)
     testImplementation(TestLibraries.testContainers)
     testImplementation(TestLibraries.junit5)
-    testRuntime(TestLibraries.jupiterEngine)
+    testRuntimeOnly(TestLibraries.jupiterEngine)
 }
 
 Deployment.initialize(project)


### PR DESCRIPTION
Remove usage of deprecated API.
Run build/clean task with `--warning-mode all` parameter to see all warnings. 