### PR TITLE
feat(core): test retry artifacts

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -13,6 +13,9 @@
       </option>
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
@@ -99,8 +102,16 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="EXTENDS_LIST_WRAP" value="1" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+      <option name="ASSIGNMENT_WRAP" value="1" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/TestEvents.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/TestEvents.kt
@@ -10,6 +10,7 @@ import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.generateTest
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 val test = generateTest()
 
@@ -89,7 +90,8 @@ private fun creteTestEvent(device: DeviceInfo, duration: Long, status: TestStatu
         device = device,
         status = status,
         startTime = whenWasSent.minusMillis(duration).toEpochMilli(),
-        endTime = whenWasSent.toEpochMilli()
+        endTime = whenWasSent.toEpochMilli(),
+        testBatchId = UUID.randomUUID().toString()
     ),
     true
 )

--- a/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/TestEvents.kt
+++ b/core/src/integrationTest/kotlin/com/malinskiy/marathon/analytics/metrics/remote/TestEvents.kt
@@ -10,7 +10,7 @@ import com.malinskiy.marathon.execution.TestStatus
 import com.malinskiy.marathon.generateTest
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.*
+import java.util.UUID
 
 val test = generateTest()
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/TestResult.kt
@@ -6,6 +6,7 @@ import com.malinskiy.marathon.test.Test
 data class TestResult(
     val test: Test,
     val device: DeviceInfo,
+    val testBatchId: String,
     val status: TestStatus,
     val startTime: Long,
     val endTime: Long,

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -133,6 +133,7 @@ class QueueActor(
             TestResult(
                 it,
                 device,
+                batch.id,
                 TestStatus.INCOMPLETE,
                 currentTimeMillis,
                 currentTimeMillis + 1

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -11,9 +11,9 @@ import java.nio.file.Paths.get
 
 @Suppress("TooManyFunctions")
 class FileManager(private val output: File) {
-    fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo, test: Test): File {
+    fun createFile(fileType: FileType, pool: DevicePoolId, device: DeviceInfo, test: Test, testBatchId: String? = null): File {
         val directory = createDirectory(fileType, pool, device)
-        val filename = createFilename(test, fileType)
+        val filename = createFilename(test, fileType, testBatchId)
         return createFile(directory, filename)
     }
 
@@ -56,7 +56,8 @@ class FileManager(private val output: File) {
 
     private fun createFile(directory: Path, filename: String): File = File(directory.toFile(), filename)
 
-    private fun createFilename(test: Test, fileType: FileType): String = "${test.toTestName()}.${fileType.suffix}"
+    private fun createFilename(test: Test, fileType: FileType, testBatchId: String? = null): String =
+        "${test.toTestName()}${testBatchId?.let { "-$it" } ?: ""}.${fileType.suffix}"
 
     private fun createFilename(device: DeviceInfo, fileType: FileType): String = "${device.serialNumber}.${fileType.suffix}"
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
@@ -90,7 +90,13 @@ class HtmlSummaryReporter(
             )
 
             pool.tests.map { it to File(File(poolsDir, pool.poolId.name), it.device.serialNumber).apply { mkdirs() } }
-                .map { (test, testDir) -> Triple(test, test.toHtmlFullTest(poolId = pool.poolId.name), testDir) }
+                .map { (test, testDir) ->
+                    Triple(
+                        test,
+                        test.toHtmlFullTest(poolId = pool.poolId.name, batchId = test.testBatchId),
+                        testDir
+                    )
+                }
                 .forEach { (test, htmlTest, testDir) ->
                     val testJson = gson.toJson(htmlTest)
                     val testHtmlFile = File(testDir, "${htmlTest.id}.html")
@@ -154,8 +160,8 @@ class HtmlSummaryReporter(
         modelName = model
     )
 
-    private fun TestResult.receiveScreenshotPath(poolId: String): String {
-        val screenshotRelativePath = "/screenshot/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}.gif"
+    private fun TestResult.receiveScreenshotPath(poolId: String, batchId: String): String {
+        val screenshotRelativePath = "/screenshot/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}-$batchId.gif"
         val screenshotFullPath = File(rootOutput, screenshotRelativePath)
         return when (device.deviceFeatures.contains(DeviceFeature.SCREENSHOT) && screenshotFullPath.exists()) {
             true -> "../../../..${screenshotRelativePath.replace("#", "%23")}"
@@ -163,8 +169,8 @@ class HtmlSummaryReporter(
         }
     }
 
-    private fun TestResult.receiveVideoPath(poolId: String): String {
-        val videoRelativePath = "/video/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}.mp4"
+    private fun TestResult.receiveVideoPath(poolId: String, batchId: String): String {
+        val videoRelativePath = "/video/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}-$batchId.mp4"
         val videoFullPath = File(rootOutput, videoRelativePath)
         return when (device.deviceFeatures.contains(DeviceFeature.VIDEO) && videoFullPath.exists()) {
             true -> "../../../..${videoRelativePath.replace("#", "%23")}"
@@ -172,8 +178,8 @@ class HtmlSummaryReporter(
         }
     }
 
-    private fun TestResult.receiveLogPath(poolId: String): String {
-        val logRelativePath = "/logs/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}.log"
+    private fun TestResult.receiveLogPath(poolId: String, batchId: String): String {
+        val logRelativePath = "/logs/$poolId/${device.serialNumber}/${test.pkg}.${test.clazz}#${test.method}-$batchId.log"
         val logFullPath = File(rootOutput, logRelativePath)
         return when (device.deviceFeatures.contains(DeviceFeature.VIDEO) && logFullPath.exists()) {
             true -> "../../../..${logRelativePath.replace("#", "%23")}"
@@ -181,7 +187,7 @@ class HtmlSummaryReporter(
         }
     }
 
-    fun TestResult.toHtmlFullTest(poolId: String) = HtmlFullTest(
+    fun TestResult.toHtmlFullTest(poolId: String, batchId: String) = HtmlFullTest(
         poolId = poolId,
         id = "${test.pkg}.${test.clazz}.${test.method}",
         packageName = test.pkg,
@@ -193,9 +199,9 @@ class HtmlSummaryReporter(
         diagnosticVideo = device.deviceFeatures.contains(DeviceFeature.VIDEO),
         diagnosticScreenshots = device.deviceFeatures.contains(DeviceFeature.SCREENSHOT),
         stacktrace = stacktrace,
-        screenshot = receiveScreenshotPath(poolId),
-        video = receiveVideoPath(poolId),
-        logFile = receiveLogPath(poolId)
+        screenshot = receiveScreenshotPath(poolId, batchId),
+        video = receiveVideoPath(poolId, batchId),
+        logFile = receiveLogPath(poolId, batchId)
     )
 
     fun TestStatus.toHtmlStatus() = when (this) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/logs/LogWriter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/logs/LogWriter.kt
@@ -8,8 +8,8 @@ import com.malinskiy.marathon.test.Test
 import java.io.File
 
 class LogWriter(private val fileManager: FileManager) {
-    fun saveLogs(test: Test, devicePoolId: DevicePoolId, device: DeviceInfo, logs: List<String>): File {
-        return fileManager.createFile(FileType.LOG, devicePoolId, device, test).apply {
+    fun saveLogs(test: Test, devicePoolId: DevicePoolId, testBatchId: String, device: DeviceInfo, logs: List<String>): File {
+        return fileManager.createFile(FileType.LOG, devicePoolId, device, test, testBatchId = testBatchId).apply {
             writeText(logs.joinToString("\n"))
         }
     }

--- a/core/src/test/kotlin/com/malinskiy/marathon/TestResultsGenerator.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/TestResultsGenerator.kt
@@ -9,6 +9,7 @@ fun generateTestResult(): TestResult = generateTestResult(generateTest())
 fun generateTestResult(test: Test): TestResult = TestResult(
     test,
     createDeviceInfo(),
+    "stub-batch",
     TestStatus.PASSED,
     0,
     10000

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/QueueActorTest.kt
@@ -241,7 +241,8 @@ private fun createTestResult(test: MarathonTest, status: TestStatus) = TestResul
     startTime = 0,
     endTime = 0,
     stacktrace = null,
-    attachments = emptyList()
+    attachments = emptyList(),
+    testBatchId = "stub-batch"
 )
 
 private fun createQueueActor(

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/queue/TestResultReporterTest.kt
@@ -82,9 +82,9 @@ class TestResultReporterTest {
     fun `default config, success - failure - failure, should report success`() {
         val filter = filterDefault()
 
-        val r1 = TestResult(test, deviceInfo, TestStatus.PASSED, 0, 1)
-        val r2 = TestResult(test, deviceInfo, TestStatus.FAILURE, 2, 3)
-        val r3 = TestResult(test, deviceInfo, TestStatus.FAILURE, 4, 5)
+        val r1 = TestResult(test, deviceInfo, "stub-batch", TestStatus.PASSED, 0, 1)
+        val r2 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 2, 3)
+        val r3 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 4, 5)
 
         filter.testFinished(deviceInfo, r1)
         filter.testFailed(deviceInfo, r2)
@@ -102,9 +102,9 @@ class TestResultReporterTest {
     fun `default config, failure - failure - success, should report success`() {
         val filter = filterDefault()
 
-        val r1 = TestResult(test, deviceInfo, TestStatus.FAILURE, 0, 1)
-        val r2 = TestResult(test, deviceInfo, TestStatus.FAILURE, 2, 3)
-        val r3 = TestResult(test, deviceInfo, TestStatus.PASSED, 4, 5)
+        val r1 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 0, 1)
+        val r2 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 2, 3)
+        val r3 = TestResult(test, deviceInfo, "stub-batch", TestStatus.PASSED, 4, 5)
 
         filter.testFailed(deviceInfo, r1)
         filter.testFailed(deviceInfo, r2)
@@ -122,9 +122,9 @@ class TestResultReporterTest {
     fun `strict config, success - failure - failure, should report failure`() {
         val filter = filterStrict()
 
-        val r1 = TestResult(test, deviceInfo, TestStatus.PASSED, 0, 1)
-        val r2 = TestResult(test, deviceInfo, TestStatus.FAILURE, 2, 3)
-        val r3 = TestResult(test, deviceInfo, TestStatus.FAILURE, 4, 5)
+        val r1 = TestResult(test, deviceInfo, "stub-batch", TestStatus.PASSED, 0, 1)
+        val r2 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 2, 3)
+        val r3 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 4, 5)
 
         filter.testFinished(deviceInfo, r1)
         filter.testFailed(deviceInfo, r2)
@@ -142,9 +142,9 @@ class TestResultReporterTest {
     fun `strict config, failure - success - success, should report failure`() {
         val filter = filterStrict()
 
-        val r1 = TestResult(test, deviceInfo, TestStatus.FAILURE, 0, 1)
-        val r2 = TestResult(test, deviceInfo, TestStatus.PASSED, 2, 3)
-        val r3 = TestResult(test, deviceInfo, TestStatus.PASSED, 4, 5)
+        val r1 = TestResult(test, deviceInfo, "stub-batch", TestStatus.FAILURE, 0, 1)
+        val r2 = TestResult(test, deviceInfo, "stub-batch", TestStatus.PASSED, 2, 3)
+        val r3 = TestResult(test, deviceInfo, "stub-batch", TestStatus.PASSED, 4, 5)
 
         filter.testFailed(deviceInfo, r1)
         filter.testFinished(deviceInfo, r2)

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
@@ -115,6 +115,7 @@ class ExecutionReportTest {
             TestResult(
                 MarathonTest("com", "example", methodName, emptyList()),
                 deviceInfo,
+                "stub-batch",
                 status,
                 0,
                 100

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
@@ -173,6 +173,7 @@ fun createTestEvent(
         TestResult(
             MarathonTest("com", "example", methodName, emptyList()),
             deviceInfo,
+            "stub-batch",
             status,
             1541675929849,
             1541675941768,

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -243,10 +243,10 @@ abstract class BaseAndroidDevice(
         val recordConfiguration = this@BaseAndroidDevice.androidConfiguration.screenRecordConfiguration
         val screenRecordingPolicy = configuration.screenRecordingPolicy
         val recorderListener = selectRecorderType(features, recordConfiguration)?.let { feature ->
-            prepareRecorderListener(feature, fileManager, devicePoolId, screenRecordingPolicy, attachmentProviders)
+            prepareRecorderListener(feature, fileManager, devicePoolId, testBatch.id, screenRecordingPolicy, attachmentProviders)
         } ?: NoOpTestRunListener()
 
-        val logCatListener = LogCatListener(this, devicePoolId, LogWriter(fileManager))
+        val logCatListener = LogCatListener(this, devicePoolId, testBatch.id, LogWriter(fileManager))
             .also { attachmentProviders.add(it) }
 
         val fileSyncTestRunListener =
@@ -265,7 +265,8 @@ abstract class BaseAndroidDevice(
     }
 
     private fun prepareRecorderListener(
-        feature: DeviceFeature, fileManager: FileManager, devicePoolId: DevicePoolId, screenRecordingPolicy: ScreenRecordingPolicy,
+        feature: DeviceFeature, fileManager: FileManager, devicePoolId: DevicePoolId, testBatchId: String,
+        screenRecordingPolicy: ScreenRecordingPolicy,
         attachmentProviders: MutableList<AttachmentProvider>
     ): NoOpTestRunListener =
         when (feature) {
@@ -273,6 +274,7 @@ abstract class BaseAndroidDevice(
                 ScreenRecorderTestRunListener(
                     fileManager,
                     devicePoolId,
+                    testBatchId,
                     this,
                     androidConfiguration.screenRecordConfiguration.videoConfiguration,
                     screenRecordingPolicy,
@@ -285,6 +287,7 @@ abstract class BaseAndroidDevice(
                 ScreenCapturerTestRunListener(
                     fileManager,
                     devicePoolId,
+                    testBatchId,
                     this,
                     screenRecordingPolicy,
                     androidConfiguration.screenRecordConfiguration.screenshotConfiguration,

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/RemoteFileManager.kt
@@ -18,13 +18,13 @@ class RemoteFileManager(private val device: AndroidDevice) {
         device.criticalExecuteShellCommand("rm -r $outputDir", "Could not delete remote directory: $outputDir")
     }
 
-    fun remoteVideoForTest(test: Test): String {
-        return remoteFileForTest(videoFileName(test))
+    fun remoteVideoForTest(test: Test, testBatchId: String): String {
+        return remoteFileForTest(videoFileName(test, testBatchId))
     }
 
     private fun remoteFileForTest(filename: String): String {
         return "$outputDir/$filename"
     }
 
-    private fun videoFileName(test: Test): String = "${test.pkg}.${test.clazz}-${test.method}.mp4"
+    private fun videoFileName(test: Test, testBatchId: String): String = "${test.pkg}.${test.clazz}-${test.method}-$testBatchId.mp4"
 }

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/LogCatListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/LogCatListener.kt
@@ -14,6 +14,7 @@ import com.malinskiy.marathon.report.logs.LogWriter
 class LogCatListener(
     private val device: AndroidDevice,
     private val devicePoolId: DevicePoolId,
+    private val testBatchId: String,
     private val logWriter: LogWriter
 ) : NoOpTestRunListener(), AttachmentProvider, LineListener {
     private val attachmentListeners = mutableListOf<AttachmentListener>()
@@ -35,7 +36,7 @@ class LogCatListener(
     override suspend fun testEnded(test: TestIdentifier, testMetrics: Map<String, String>) {
         device.removeLogcatListener(this)
 
-        val file = logWriter.saveLogs(test.toTest(), devicePoolId, device.toDeviceInfo(), listOf(stringBuffer.toString()))
+        val file = logWriter.saveLogs(test.toTest(), devicePoolId, testBatchId, device.toDeviceInfo(), listOf(stringBuffer.toString()))
 
         attachmentListeners.forEach { it.onAttachment(test.toTest(), Attachment(file, AttachmentType.LOG)) }
     }

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -105,6 +105,7 @@ class TestRunResultsListener(
             TestResult(
                 it,
                 device.toDeviceInfo(),
+                testBatch.id,
                 TestStatus.INCOMPLETE,
                 lastCompletedTestEndTime,
                 timer.currentTimeMillis(),
@@ -140,6 +141,7 @@ class TestRunResultsListener(
         return TestResult(
             test = testInstanceFromBatch ?: test,
             device = device.toDeviceInfo(),
+            testBatchId = testBatch.id,
             status = value.status.toMarathonStatus(),
             startTime = value.startTime,
             endTime = value.endTime,

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturer.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturer.kt
@@ -26,6 +26,7 @@ import kotlin.system.measureTimeMillis
 class ScreenCapturer(
     val device: AndroidDevice,
     private val poolId: DevicePoolId,
+    private val testBatchId: String,
     private val fileManager: FileManager,
     private val configuration: ScreenshotConfiguration,
     private val timeout: Duration
@@ -35,7 +36,8 @@ class ScreenCapturer(
         var outputStream: FileImageOutputStream? = null
         val writer: GifSequenceWriter? = null
         try {
-            val outputStream = FileImageOutputStream(fileManager.createFile(FileType.SCREENSHOT, poolId, device.toDeviceInfo(), test))
+            val outputStream =
+                FileImageOutputStream(fileManager.createFile(FileType.SCREENSHOT, poolId, device.toDeviceInfo(), test, testBatchId))
             val writer = GifSequenceWriter(outputStream, TYPE_INT_ARGB, configuration.delayMs, true)
             var targetRotation = detectCurrentDeviceOrientation()
             while (coroutineContext.isActive) {

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturerTestRunListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/screenshot/ScreenCapturerTestRunListener.kt
@@ -15,16 +15,17 @@ import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.attachment.AttachmentListener
 import com.malinskiy.marathon.report.attachment.AttachmentProvider
 import com.malinskiy.marathon.test.toSimpleSafeTestName
-import java.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
+import java.time.Duration
 
 class ScreenCapturerTestRunListener(
     private val fileManager: FileManager,
     private val pool: DevicePoolId,
+    private val testBatchId: String,
     private val device: AndroidDevice,
     private val screenRecordingPolicy: ScreenRecordingPolicy,
     private val screenshotConfiguration: ScreenshotConfiguration,
@@ -41,7 +42,7 @@ class ScreenCapturerTestRunListener(
 
     private var supervisorJob: Job? = null
     private var hasFailed: Boolean = false
-    private val screenCapturer = ScreenCapturer(device, pool, fileManager, screenshotConfiguration, timeout)
+    private val screenCapturer = ScreenCapturer(device, pool, testBatchId, fileManager, screenshotConfiguration, timeout)
     private val logger = MarathonLogging.logger(ScreenCapturerTestRunListener::class.java.simpleName)
 
     override suspend fun testStarted(test: TestIdentifier) {

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/logparser/listener/ProgressReportingListener.kt
@@ -43,6 +43,7 @@ class ProgressReportingListener(
             TestResult(
                 it,
                 device.toDeviceInfo(),
+                testBatchId = testBatch.id,
                 TestStatus.FAILURE,
                 lastCompletedTestEndTime,
                 lastCompletedTestEndTime,
@@ -53,12 +54,32 @@ class ProgressReportingListener(
 
     override fun testFailed(test: Test, startTime: Long, endTime: Long) {
         progressReporter.testFailed(poolId, device.toDeviceInfo(), test)
-        failure.add(TestResult(test, device.toDeviceInfo(), TestStatus.FAILURE, startTime, endTime, testLogListener.getLastLog()))
+        failure.add(
+            TestResult(
+                test,
+                device.toDeviceInfo(),
+                testBatch.id,
+                TestStatus.FAILURE,
+                startTime,
+                endTime,
+                testLogListener.getLastLog()
+            )
+        )
     }
 
     override fun testPassed(test: Test, startTime: Long, endTime: Long) {
         progressReporter.testPassed(poolId, device.toDeviceInfo(), test)
-        success.add(TestResult(test, device.toDeviceInfo(), TestStatus.PASSED, startTime, endTime, testLogListener.getLastLog()))
+        success.add(
+            TestResult(
+                test,
+                device.toDeviceInfo(),
+                testBatch.id,
+                TestStatus.PASSED,
+                startTime,
+                endTime,
+                testLogListener.getLastLog()
+            )
+        )
     }
 
     override fun testStarted(test: Test) {

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/StubDevice.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/StubDevice.kt
@@ -53,7 +53,7 @@ class StubDevice(
             val i = executionIndexMap.getOrDefault(it, 0)
             val result = executionResults[it]!![i]
             executionIndexMap[it] = i + 1
-            val testResult = TestResult(it, toDeviceInfo(), result, timeCounter, timeCounter + 1, null)
+            val testResult = TestResult(it, toDeviceInfo(), testBatch.id, result, timeCounter, timeCounter + 1, null)
             timeCounter += 1
             testResult
         }


### PR DESCRIPTION
This effectively saves all the failed test artifacts for default mode of execution: even if a test succeeded, you will get failed retries to investigate flaky tests.

Retry screen recordings + logs will be visible via allure report as well as available via raw file access