### PR TITLE
Remove deprecated experimentalWarning

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 
-kotlinDslPluginOptions {
-    experimentalWarning.set(false)
-}
-
 repositories {
     jcenter()
 }


### PR DESCRIPTION
According to documentation flag has no effect since `kotlin-dsl`
no longer relies on experimental features and to be removed at
Gradle 8.0.

source:
https://github.com/gradle/gradle/blob/4e71fe0d2b174d262ebb8e01f240189c9cab3849/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPluginOptions.kt#L45-L66