### PR TITLE
Add support for ANDROID_SDK_ROOT

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/ApplicationView.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/ApplicationView.kt
@@ -40,7 +40,7 @@ fun main(args: Array<String>): Unit = mainBody(
                 .registerModule(JavaTimeModule())
             val configuration = ConfigFactory(mapper).create(
                 marathonfile = marathonfile,
-                environmentReader = SystemEnvironmentReader { System.getenv(it) }
+                environmentReader = SystemEnvironmentReader()
             )
 
             val application = marathonStartKoin(configuration)

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/ApplicationView.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/ApplicationView.kt
@@ -40,7 +40,7 @@ fun main(args: Array<String>): Unit = mainBody(
                 .registerModule(JavaTimeModule())
             val configuration = ConfigFactory(mapper).create(
                 marathonfile = marathonfile,
-                environmentReader = SystemEnvironmentReader()
+                environmentReader = SystemEnvironmentReader { System.getenv(it) }
             )
 
             val application = marathonStartKoin(configuration)

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
@@ -4,7 +4,7 @@ import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import java.io.File
 
 class SystemEnvironmentReader(
-    private val environment: (String) -> String?
+    private val environment: (String) -> String? = { System.getenv(it) }
 ) : EnvironmentReader {
     override fun read() = EnvironmentConfiguration(
         androidSdk = androidSdkPath()?.let { File(it) }

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
@@ -3,6 +3,13 @@ package com.malinskiy.marathon.cli.args.environment
 import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import java.io.File
 
-class SystemEnvironmentReader : EnvironmentReader {
-    override fun read() = EnvironmentConfiguration(System.getenv("ANDROID_HOME")?.let { File(it) })
+class SystemEnvironmentReader(
+    private val environment: (String) -> String?
+) : EnvironmentReader {
+    override fun read() = EnvironmentConfiguration(
+        androidSdk = androidSdkPath()?.let { File(it) }
+    )
+
+    private fun androidSdkPath() =
+        environment("ANDROID_HOME") ?: environment("ANDROID_SDK_ROOT")
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/EnvironmentConfigurationBuilders.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/EnvironmentConfigurationBuilders.kt
@@ -1,0 +1,9 @@
+package com.malinskiy.marathon.cli.args
+
+import java.io.File
+
+fun environmentConfiguration(
+    androidSdk: File? = null
+) = EnvironmentConfiguration(
+    androidSdk = androidSdk
+)

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReaderTest.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReaderTest.kt
@@ -1,0 +1,60 @@
+package com.malinskiy.marathon.cli.args.environment
+
+import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
+import com.malinskiy.marathon.cli.args.environmentConfiguration
+import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.mock
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class SystemEnvironmentReaderTest {
+
+    private lateinit var environment: (String) -> String?
+    private lateinit var systemEnvironmentReader: SystemEnvironmentReader
+
+    private val expectedAndroidSdk = "/android"
+
+    @BeforeEach
+    fun beforeEach() {
+        environment = mock()
+        systemEnvironmentReader = SystemEnvironmentReader(environment)
+    }
+
+    @Test
+    fun `EnvironmentConfiguration should point to ANDROID_HOME`() {
+        givenEnvironment("ANDROID_HOME")
+
+        val environmentConfiguration = systemEnvironmentReader.read()
+
+        environmentConfiguration shouldBeEqualTo expectedAndroidSdk()
+    }
+
+    @Test
+    fun `EnvironmentConfiguration should point to ANDROID_SDK_ROOT`() {
+        givenEnvironment("ANDROID_SDK_ROOT")
+
+        val environmentConfiguration = systemEnvironmentReader.read()
+
+        environmentConfiguration shouldBeEqualTo expectedAndroidSdk()
+    }
+
+    @Test
+    fun `EnvironmentConfiguration should prefer ANDROID_HOME over ANDROID_SDK_ROOT`() {
+        givenEnvironment("ANDROID_HOME")
+        givenEnvironment("ANDROID_SDK_ROOT", "/android_sdk")
+
+        val environmentConfiguration = systemEnvironmentReader.read()
+
+        environmentConfiguration shouldBeEqualTo expectedAndroidSdk()
+    }
+
+    private fun expectedAndroidSdk(): EnvironmentConfiguration =
+        environmentConfiguration(androidSdk = File(expectedAndroidSdk))
+
+    private fun givenEnvironment(name: String, value: String = expectedAndroidSdk) {
+        whenever(environment.invoke(name)).thenReturn(value)
+    }
+}


### PR DESCRIPTION
ANDROID_HOME is deprecated. This PR adds support for ANDROID_SDK_ROOT.

See: https://developer.android.com/studio/command-line/variables