### PR TITLE
feat(core): add fragmentation filter

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/deserialize/TestFilterDeserializer.kt
@@ -16,6 +16,7 @@ import com.malinskiy.marathon.execution.SimpleClassnameFilter
 import com.malinskiy.marathon.execution.TestFilter
 import com.malinskiy.marathon.execution.TestMethodFilter
 import com.malinskiy.marathon.execution.TestPackageFilter
+import com.malinskiy.marathon.execution.filter.FragmentationFilter
 import com.malinskiy.marathon.execution.filter.FullyQualifiedTestnameFilter
 
 class TestFilterDeserializer : StdDeserializer<TestFilter>(TestFilter::class.java) {
@@ -56,6 +57,10 @@ class TestFilterDeserializer : StdDeserializer<TestFilter>(TestFilter::class.jav
             "annotationData" -> {
                 (node as ObjectNode).remove("type")
                 codec.treeToValue<AnnotationDataFilter>(node)
+            }
+            "fragmentation" -> {
+                (node as ObjectNode).remove("type")
+                codec.treeToValue<FragmentationFilter>(node)
             }
 
             else -> throw ConfigurationException("Unrecognized filter type $type")

--- a/core/src/main/kotlin/com/malinskiy/marathon/config/LogicalConfigurationValidator.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/config/LogicalConfigurationValidator.kt
@@ -17,5 +17,8 @@ class LogicalConfigurationValidator : ConfigurationValidator {
                 )
             }
         }
+        
+        configuration.filteringConfiguration.allowlist.forEach { it.validate() }
+        configuration.filteringConfiguration.blocklist.forEach { it.validate() }
     }
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilter.kt
@@ -1,0 +1,51 @@
+package com.malinskiy.marathon.execution.filter
+
+import com.malinskiy.marathon.exceptions.ConfigurationException
+import com.malinskiy.marathon.execution.TestFilter
+import com.malinskiy.marathon.extension.md5
+import com.malinskiy.marathon.log.MarathonLogging
+import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.toTestName
+import java.math.BigInteger
+
+/**
+ * This is a test filter similar to sharded test execution that AOSP provides
+ * https://source.android.com/devices/tech/test_infra/tradefed/architecture/advanced/sharding
+ *
+ * It is intended to be used in situations where it is not possible to connect multiple execution devices to marathon, e.g.
+ * CI setup that can schedule parallel jobs each containing a single execution device.
+ *
+ * This is a dynamic programming technique, hence the results will be sub-optimal compared to connecting multiple devices to the same test
+ * run
+ */
+class FragmentationFilter(private val index: Int, private val count: Int) : TestFilter {
+    private val logger = MarathonLogging.logger {}
+    private val power by lazy { BigInteger.valueOf(count.toLong()) }
+    private val remainder by lazy { BigInteger.valueOf(index.toLong()) }
+    private val predicate: (Test) -> Boolean = {
+        /**
+         * Randomizing the distribution via md5
+         */
+        val testNumber = it.toTestName().md5()
+        val testRemainder = testNumber % power
+        val actualRemainder = if (testRemainder < BigInteger.ZERO) {
+            testRemainder + power
+        } else {
+            testRemainder
+        }
+
+        actualRemainder == remainder
+    }
+
+    override fun validate() {
+        if (index < 0) throw ConfigurationException("Fragment index [$index] should be >= 0")
+        if (count < 0) throw ConfigurationException("Fragment count [$count] should be >= 0")
+        if (index >= count) throw ConfigurationException("Fragment index [$index] should be less than count [$count]")
+
+        logger.info { "Executing test fragment $index out of $count" }
+    }
+
+    override fun filter(tests: List<Test>): List<Test> = tests.filter(predicate)
+
+    override fun filterNot(tests: List<Test>): List<Test> = tests.filterNot(predicate)
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilter.kt
@@ -43,6 +43,10 @@ class FragmentationFilter(private val index: Int, private val count: Int) : Test
         if (index >= count) throw ConfigurationException("Fragment index [$index] should be less than count [$count]")
 
         logger.info { "Executing test fragment $index out of $count" }
+        logger.warn {
+            "Test fragmentation is a suboptimal solution in regards to the performance of your tests. " +
+                "Please consider connecting all your devices to a single test execution."
+        }
     }
 
     override fun filter(tests: List<Test>): List<Test> = tests.filter(predicate)

--- a/core/src/main/kotlin/com/malinskiy/marathon/extension/StringExtensions.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/extension/StringExtensions.kt
@@ -1,9 +1,20 @@
 package com.malinskiy.marathon.extension
 
+import java.math.BigInteger
+import java.security.MessageDigest
+
 internal fun String.withPrefix(prefix: String?): String {
     return if (prefix.isNullOrEmpty()) {
         this
     } else {
         "$prefix.$this"
     }
+}
+
+fun String.md5(): BigInteger {
+    return BigInteger(MD5.md5.digest(toByteArray(charset = Charsets.UTF_8)))
+}
+
+object MD5 {
+    val md5: MessageDigest by lazy { MessageDigest.getInstance("MD5") }
 }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/FragmentationFilterTest.kt
@@ -1,0 +1,56 @@
+package com.malinskiy.marathon.execution.filter
+
+import com.malinskiy.marathon.exceptions.ConfigurationException
+import com.malinskiy.marathon.generateTests
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContainSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import com.malinskiy.marathon.test.Test as MarathonTest
+
+class FragmentationFilterTest {
+    @Test
+    fun testFragmentsProperly() {
+        val filter0 = FragmentationFilter(0, 3)
+        val filter1 = FragmentationFilter(1, 3)
+        val filter2 = FragmentationFilter(2, 3)
+        
+        filter0.validate()
+        filter1.validate()
+        filter2.validate()
+
+        val tests: List<MarathonTest> = generateTests(15)
+
+        val fragment0 = filter0.filter(tests)
+        val fragment1 = filter1.filter(tests)
+        val fragment2 = filter2.filter(tests)
+        
+        (fragment0 + fragment1 + fragment2).size shouldBeEqualTo 15
+    }
+
+    @Test
+    fun testFilterNot() {
+        val filter0 = FragmentationFilter(0, 3)
+        val filter1 = FragmentationFilter(1, 3)
+        val filter2 = FragmentationFilter(2, 3)
+
+        filter0.validate()
+        filter1.validate()
+        filter2.validate()
+
+        val tests: List<MarathonTest> = generateTests(15)
+
+        val fragment0 = filter0.filterNot(tests)
+        val fragment1 = filter1.filter(tests)
+        val fragment2 = filter2.filter(tests)
+        
+        fragment0 shouldContainSame fragment1 + fragment2
+    }
+    
+    @Test
+    fun testThrowsException() {
+        assertThrows<ConfigurationException> { FragmentationFilter(-1, 3).validate() }
+        assertThrows<ConfigurationException> { FragmentationFilter(1, -1).validate() }
+        assertThrows<ConfigurationException> { FragmentationFilter(5, 2).validate() }
+    }
+}

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -1171,10 +1171,10 @@ run
 
 ```yaml
 filteringConfiguration:
-allowlist:
-  - type: "fragmentation"
-    index: 0
-    count: 10
+  allowlist:
+    - type: "fragmentation"
+      index: 0
+      count: 10
 ```
 
 {% endtab %} {% tab fragmentation Gradle Kotlin %}
@@ -1194,10 +1194,10 @@ marathon {
 If you want to dynamically pass the index of the test run you can use yaml envvar interpolation, e.g.:
 ```yaml
 filteringConfiguration:
-allowlist:
-  - type: "fragmentation"
-    index: ${MARATHON_FRAGMENT_INDEX}
-    count: 10
+  allowlist:
+    - type: "fragmentation"
+      index: ${MARATHON_FRAGMENT_INDEX}
+      count: 10
 ```
 
 and then execute the testing as following:

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -1159,10 +1159,13 @@ marathon {
 {% endtab %} {% endtabs %}
 
 ## Fragmented execution of tests
-This is a test filter similar to sharded test execution that [AOSP provides][6]
+This is a test filter similar to sharded test execution that [AOSP provides][6].
 
 It is intended to be used in situations where it is not possible to connect multiple execution devices to a single test run, e.g. CI setup
-that can schedule parallel jobs each containing a single execution device.
+that can schedule parallel jobs each containing a single execution device. There are two parameters for using fragmentation:
+
+* **count** - the number of overall fragments (e.g. 10 parallel execution)
+* **index** - current execution index (in our case of 10 executions valid indexes are 0..9)
 
 This is a dynamic programming technique, hence the results will be sub-optimal compared to connecting multiple devices to the same test
 run

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -120,7 +120,8 @@ Here you will find a list of currently supported configuration parameters and ex
 additional parameters might not be supported by all vendor modules. If you find that something doesn't work - please submit an issue for a
 vendor module at fault.
 
-* TOC {:toc}
+* TOC 
+{:toc}
 
 # General parameters
 
@@ -1157,6 +1158,56 @@ marathon {
 
 {% endtab %} {% endtabs %}
 
+## Fragmented execution of tests
+This is a test filter similar to sharded test execution that [AOSP provides][6]
+
+It is intended to be used in situations where it is not possible to connect multiple execution devices to a single test run, e.g. CI setup
+that can schedule parallel jobs each containing a single execution device.
+
+This is a dynamic programming technique, hence the results will be sub-optimal compared to connecting multiple devices to the same test
+run
+
+{% tabs fragmentation %} {% tab fragmentation Marathonfile %}
+
+```yaml
+filteringConfiguration:
+allowlist:
+  - type: "fragmentation"
+    index: 0
+    count: 10
+```
+
+{% endtab %} {% tab fragmentation Gradle Kotlin %}
+
+```kotlin
+marathon {
+  filteringConfiguration {
+    allowlist = mutableListOf(
+      FragmentationFilter(index = 0, count = 10)
+    )
+  }
+}
+```
+
+{% endtab %} {% endtabs %}
+
+If you want to dynamically pass the index of the test run you can use yaml envvar interpolation, e.g.:
+```yaml
+filteringConfiguration:
+allowlist:
+  - type: "fragmentation"
+    index: ${MARATHON_FRAGMENT_INDEX}
+    count: 10
+```
+
+and then execute the testing as following:
+
+```bash
+$ MARATHON_FRAGMENT_INDEX=0 marathon
+```
+
+To pass the fragment index in gradle refer to the [Gradle's dynamic project properties](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#properties)
+
 ## Test class regular expression
 
 By default, test classes are found using the ```"^((?!Abstract).)*Test[s]*$"``` regex. You can override this if you need to.
@@ -1491,3 +1542,4 @@ See relevant vendor module page, e.g. [Android][3] or [iOS][4]
 [3]: {% post_url 2018-11-19-android %}
 [4]: {% post_url 2018-11-19-ios %}
 [5]: https://github.com/MarathonLabs/marathon/blob/develop/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+[6]: https://source.android.com/devices/tech/test_infra/tradefed/architecture/advanced/sharding


### PR DESCRIPTION
This is a test filter similar to sharded test execution that AOSP provides https://source.android.com/devices/tech/test_infra/tradefed/architecture/advanced/sharding

It is intended to be used in situations where it is not possible to connect multiple execution devices to marathon, e.g. CI setup that can schedule parallel jobs each containing a single execution device.

This is a dynamic programming technique, hence the results will be sub-optimal compared to connecting multiple devices to the same test run

Apply as following:
```yaml
filteringConfiguration:
  allowlist:
    - type: "fragmentation"
      index: 0
      count: 10
```

If you want to dynamically pass the index of the test run you can use yaml envvar interpolation, e.g.:
```yaml
filteringConfiguration:
  allowlist:
    - type: "fragmentation"
      index: ${MARATHON_FRAGMENT_INDEX}
      count: ${MARATHON_FRAGMENT_COUNT}
```

and then execute the testing as following:

```bash
$ MARATHON_FRAGMENT_COUNT=10 MARATHON_FRAGMENT_INDEX=0 marathon
```

The implementation currently makes a stable decision based on the FQTN. Assuming the count of fragments doesn't change, the test will always be executed in the fragment under the same index. Essentially this makes newly added tests randomly distributed between fragments while guaranteeing that tests are tied to a specific fragment. This execution model doesn't account however for the test duration so an expected edge case is that a particular fragment might exist that will be executed for much longer than other fragments.

Fixes #353