### PR TITLE
fix(android): invoke before/after test run lifecycle hooks when test …

### DIFF
--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
@@ -44,8 +44,10 @@ class AndroidDeviceTestRunner(private val device: AdamAndroidDevice, private val
         val ignoredTests = rawTestBatch.tests.filter { test -> test.isIgnored() }
         val testBatch = TestBatch(rawTestBatch.tests - ignoredTests, rawTestBatch.id)
         if (testBatch.tests.isEmpty()) {
+            listener.beforeTestRun()
             notifyIgnoredTest(ignoredTests, listener)
             listener.testRunEnded(0, emptyMap())
+            listener.afterTestRun()
             return
         }
 

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/AndroidDeviceTestRunner.kt
@@ -36,8 +36,10 @@ class AndroidDeviceTestRunner(private val device: DdmlibAndroidDevice, private v
         val testBatch = TestBatch(rawTestBatch.tests - ignoredTests)
         val listenerAdapter = listener.toDdmlibTestListener()
         if (testBatch.tests.isEmpty()) {
+            listener.beforeTestRun()
             notifyIgnoredTest(ignoredTests, listenerAdapter)
             listener.testRunEnded(0, emptyMap())
+            listener.afterTestRun()
             return
         }
 

--- a/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerTest.kt
+++ b/vendor/vendor-android/ddmlib/src/test/kotlin/com/malinskiy/marathon/android/AndroidDeviceTestRunnerTest.kt
@@ -192,10 +192,12 @@ class AndroidDeviceTestRunnerTest {
         val listener = mock<AndroidTestRunListener>()
         runBlocking {
             androidDeviceTestRunner.execute(configuration, batch, listener)
+            verify(listener).beforeTestRun()
             verify(listener).testStarted(eq(identifier))
             verify(listener).testIgnored(eq(identifier))
             verify(listener).testEnded(eq(identifier), eq(emptyMap()))
             verify(listener).testRunEnded(eq(0), eq(emptyMap()))
+            verify(listener).afterTestRun()
         }
         verifyNoMoreInteractions(listener)
     }


### PR DESCRIPTION
…batch consists only of ignored tests