### PR TITLE
fix(core): test retries should not fail the exit code

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
@@ -52,16 +52,20 @@ class ProgressReporter(private val configuration: Configuration) {
         }
     }
 
-    fun totalTests(poolId: DevicePoolId, size: Int) {
-        execute(poolId) { it.totalTests(size) }
+    fun testCountExpectation(poolId: DevicePoolId, size: Int) {
+        execute(poolId) { it.testCountExpectation(size) }
     }
 
     fun removeTests(poolId: DevicePoolId, count: Int) {
         execute(poolId) { it.removeTests(count) }
     }
 
-    fun addTests(poolId: DevicePoolId, count: Int) {
-        execute(poolId) { it.addTests(count) }
+    fun addTestDiscoveredDuringRuntime(poolId: DevicePoolId, test: Test) {
+        execute(poolId) { it.addTestDiscoveredDuringRuntime(test) }
+    }
+
+    fun addRetries(poolId: DevicePoolId, count: Int) {
+        execute(poolId) { it.addTestRetries(count) }
     }
 
     fun progress(): Float {

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -56,7 +56,7 @@ class QueueActor(
 
     init {
         queue.addAll(testShard.tests + testShard.flakyTests)
-        progressReporter.totalTests(poolId, queue.size)
+        progressReporter.testCountExpectation(poolId, queue.size)
     }
 
     override suspend fun receive(msg: QueueMessage) {
@@ -123,7 +123,7 @@ class QueueActor(
                 testResultReporter.testIncomplete(device, test, final = false)
             }
             returnTests(uncompleted.map { it.test })
-            progressReporter.addTests(poolId, uncompleted.size)
+            progressReporter.addRetries(poolId, uncompleted.size)
         }
     }
 
@@ -180,7 +180,7 @@ class QueueActor(
         logger.debug { "handle failed tests ${device.serialNumber}" }
         val retryList = retry.process(poolId, failed, testShard)
 
-        progressReporter.addTests(poolId, retryList.size)
+        progressReporter.addRetries(poolId, retryList.size)
         queue.addAll(retryList.map { it.test })
         retryList.forEach {
             testResultReporter.retryTest(device, it)

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
@@ -7,7 +7,7 @@ import com.malinskiy.marathon.test.Mocks
 import com.malinskiy.marathon.test.StubDevice
 import com.malinskiy.marathon.test.StubDeviceProvider
 import com.malinskiy.marathon.test.TestVendorConfiguration
-import org.amshove.kluent.shouldEqualTo
+import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
 import java.io.File
 import com.malinskiy.marathon.test.Test as MarathonTest
@@ -53,50 +53,50 @@ class ProgressReporterTest {
         val test3 = MarathonTest("com.example", "SimpleTest", "method3", emptyList())
 
         reporter.testCountExpectation(poolId, 3)
-        reporter.progress().shouldEqualTo(.0f)
+        reporter.progress().shouldBeEqualTo(.0f)
 
         /**
          * test 1 passed
          */
         reporter.testStarted(poolId, deviceInfo, test1)
         reporter.testPassed(poolId, deviceInfo, test1)
-        reporter.progress().shouldEqualTo(1 / 3f)
+        reporter.progress().shouldBeEqualTo(1 / 3f)
 
         /**
          * test 2 failed
          */
         reporter.testStarted(poolId, deviceInfo, test2)
         reporter.testFailed(poolId, deviceInfo, test2)
-        reporter.progress().shouldEqualTo(2 / 3f)
+        reporter.progress().shouldBeEqualTo(2 / 3f)
 
         /**
          * adding 4 retries for test2 and then test 2 passes once
          */
         reporter.addRetries(poolId, 4)
-        reporter.progress().shouldEqualTo(2 / 7f)
+        reporter.progress().shouldBeEqualTo(2 / 7f)
         reporter.testStarted(poolId, deviceInfo, test2)
         reporter.testPassed(poolId, deviceInfo, test2)
-        reporter.progress().shouldEqualTo(3 / 7f)
+        reporter.progress().shouldBeEqualTo(3 / 7f)
 
         /**
          * 1 retry of test 2 fails
          */
         reporter.testStarted(poolId, deviceInfo, test2)
         reporter.testFailed(poolId, deviceInfo, test2)
-        reporter.progress().shouldEqualTo(4 / 7f)
+        reporter.progress().shouldBeEqualTo(4 / 7f)
 
         /**
          * 1 retry of test 2 is ignored
          */
         reporter.testStarted(poolId, deviceInfo, test2)
         reporter.testIgnored(poolId, deviceInfo, test2)
-        reporter.progress().shouldEqualTo(5 / 7f)
+        reporter.progress().shouldBeEqualTo(5 / 7f)
 
         /**
          * removing one retry of test 2
          */
         reporter.removeTests(poolId, 1)
-        reporter.progress().shouldEqualTo(5 / 6f)
+        reporter.progress().shouldBeEqualTo(5 / 6f)
 
         /**
          * test 3 is ignored (assumption failure or just ignore)
@@ -104,6 +104,45 @@ class ProgressReporterTest {
         reporter.testStarted(poolId, deviceInfo, test3)
         reporter.testIgnored(poolId, deviceInfo, test3)
         val progress = reporter.progress()
-        progress.shouldEqualTo(6 / 6f)
+        progress.shouldBeEqualTo(6 / 6f)
+    }
+
+    @Test
+    fun shouldReportProgressForOnePoolWithRuntimeDiscovery() {
+        val poolId = DevicePoolId("testpool")
+
+        val test0 = MarathonTest("com.example", "SimpleTest", "method[0]", emptyList())
+        val test1 = MarathonTest("com.example", "SimpleTest", "method[1]", emptyList())
+        val test2 = MarathonTest("com.example", "SimpleTest", "method[2]", emptyList())
+
+        reporter.testCountExpectation(poolId, 1)
+        reporter.progress().shouldBeEqualTo(.0f)
+
+        /**
+         * [0] passed
+         */
+        reporter.testStarted(poolId, deviceInfo, test0)
+        reporter.testPassed(poolId, deviceInfo, test0)
+        reporter.progress().shouldBeEqualTo(1 / 1f)
+
+        /**
+         * [1] passed
+         */
+        reporter.testStarted(poolId, deviceInfo, test1)
+        reporter.testPassed(poolId, deviceInfo, test1)
+        reporter.progress().shouldBeEqualTo(2 / 1f)
+
+        /**
+         * [2] passed
+         */
+        reporter.testStarted(poolId, deviceInfo, test2)
+        reporter.testPassed(poolId, deviceInfo, test2)
+        reporter.progress().shouldBeEqualTo(3 / 1f)
+
+        reporter.addTestDiscoveredDuringRuntime(poolId, test1)
+        reporter.addTestDiscoveredDuringRuntime(poolId, test2)
+
+        val progress = reporter.progress()
+        progress.shouldBeEqualTo(6 / 6f)
     }
 }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterTest.kt
@@ -52,7 +52,7 @@ class ProgressReporterTest {
         val test2 = MarathonTest("com.example", "SimpleTest", "method2", emptyList())
         val test3 = MarathonTest("com.example", "SimpleTest", "method3", emptyList())
 
-        reporter.totalTests(poolId, 3)
+        reporter.testCountExpectation(poolId, 3)
         reporter.progress().shouldEqualTo(.0f)
 
         /**
@@ -72,7 +72,7 @@ class ProgressReporterTest {
         /**
          * adding 4 retries for test2 and then test 2 passes once
          */
-        reporter.addTests(poolId, 4)
+        reporter.addRetries(poolId, 4)
         reporter.progress().shouldEqualTo(2 / 7f)
         reporter.testStarted(poolId, deviceInfo, test2)
         reporter.testPassed(poolId, deviceInfo, test2)

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
@@ -91,4 +91,29 @@ class PoolProgressTrackerTest {
         tracker.testPassed(test)
         tracker.aggregateResult().shouldBeEqualTo(true)
     }
+
+    @Test
+    fun withRuntimeDiscovery() {
+        val tracker = PoolProgressTracker(createConfiguration(strictMode = false))
+        val test0 = MarathonTest(
+            pkg = "com.malinskiy.marathon",
+            clazz = "ParameterizedTest",
+            method = "test[0]",
+            metaProperties = emptyList()
+        )
+        val test1 = MarathonTest(
+            pkg = "com.malinskiy.marathon",
+            clazz = "ParameterizedTest",
+            method = "test[1]",
+            metaProperties = emptyList()
+        )
+
+        tracker.testCountExpectation(1)
+        tracker.testStarted(test0)
+        tracker.testPassed(test0)
+        tracker.testStarted(test1)
+        tracker.testPassed(test1)
+        tracker.addTestDiscoveredDuringRuntime(test1)
+        tracker.aggregateResult().shouldBeEqualTo(true)
+    }
 }

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerTest.kt
@@ -5,7 +5,6 @@ import com.malinskiy.marathon.test.Mocks
 import com.malinskiy.marathon.test.StubDeviceProvider
 import com.malinskiy.marathon.test.TestVendorConfiguration
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldEqualTo
 import org.junit.jupiter.api.Test
 import java.io.File
 import com.malinskiy.marathon.test.Test as MarathonTest
@@ -51,32 +50,45 @@ class PoolProgressTrackerTest {
     @Test
     fun nonStrictMode_case1() {
         val tracker = PoolProgressTracker(createConfiguration(strictMode = false))
-        tracker.totalTests(1)
+        tracker.testCountExpectation(1)
         tracker.testStarted(test)
         tracker.testPassed(test)
         tracker.testFailed(test)
-        tracker.aggregateResult().shouldEqualTo(true)
+        tracker.aggregateResult().shouldBeEqualTo(true)
         tracker.testPassed(test)
-        tracker.aggregateResult().shouldEqualTo(true)
+        tracker.aggregateResult().shouldBeEqualTo(true)
     }
 
     @Test
     fun strictMode_case1() {
         val tracker = PoolProgressTracker(createConfiguration(strictMode = true))
-        tracker.totalTests(1)
+        tracker.testCountExpectation(1)
         tracker.testStarted(test)
         tracker.testPassed(test)
         tracker.testFailed(test)
-        tracker.aggregateResult().shouldEqualTo(false)
+        tracker.aggregateResult().shouldBeEqualTo(false)
         tracker.testPassed(test)
-        tracker.aggregateResult().shouldEqualTo(false)
+        tracker.aggregateResult().shouldBeEqualTo(false)
     }
-    
+
     @Test
     fun all_incomplete() {
-        val tracker = PoolProgressTracker(createConfiguration(strictMode = false)).apply { 
-            totalTests(1)
+        val tracker = PoolProgressTracker(createConfiguration(strictMode = false)).apply {
+            testCountExpectation(1)
         }
         tracker.aggregateResult() shouldBeEqualTo false
+    }
+
+    @Test
+    fun withRetries() {
+        val tracker = PoolProgressTracker(createConfiguration(strictMode = false))
+
+        tracker.testCountExpectation(1)
+        tracker.testStarted(test)
+        tracker.testFailed(test)
+        tracker.addTestRetries(1)
+        tracker.testStarted(test)
+        tracker.testPassed(test)
+        tracker.aggregateResult().shouldBeEqualTo(true)
     }
 }

--- a/sample/android-app/metrics.sh
+++ b/sample/android-app/metrics.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+./gradlew assemble assembleAndroidTest
+adb uninstall com.example.test
+adb uninstall com.example
+adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk          
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+
+adb shell am instrument -w -r -e class com.example.MainActivityTest  com.example.test/androidx.test.runner.AndroidJUnitRunner

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListener.kt
@@ -130,7 +130,7 @@ class TestRunResultsListener(
                 } else {
                     result[realIdentifier]?.status = maybeExistingParameterizedResult.status + e.value.status
                     //Needed for proper result aggregation
-                    progressReporter.addTests(poolId, 1)
+                    progressReporter.addTestDiscoveredDuringRuntime(poolId, test.toTest())
                 }
             } else {
                 result[test] = e.value

--- a/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListenerTest.kt
+++ b/vendor/vendor-android/base/src/test/kotlin/com/malinskiy/marathon/android/executor/listeners/TestRunResultsListenerTest.kt
@@ -584,7 +584,14 @@ class TestRunResultsListenerTest {
             )
             assertThat(result.failed).isEmpty()
             assertThat(result.uncompleted).isEmpty()
-            verify(progressReporter, times(2)).addTests(poolId, 1)
+            
+            /**
+             * Due to the need for consistency first parameterized test does not end up being reported to remove the need to remove the
+             * parent test
+             */
+            verify(progressReporter, times(0)).addTestDiscoveredDuringRuntime(poolId, id0.toTest())
+            verify(progressReporter, times(1)).addTestDiscoveredDuringRuntime(poolId, id1.toTest())
+            verify(progressReporter, times(1)).addTestDiscoveredDuringRuntime(poolId, id2.toTest())
         }
     }
 


### PR DESCRIPTION
```
Allure environment data saved.
Marathon run finished:
Device pool omni:
	26 passed, 0 failed, 3 ignored tests
	Flakiness overhead: 14499ms
	Raw: 26 passed, 5 failed, 3 ignored, 0 incomplete tests
	Failed tests:
		com.example.MainActivityFlakyTest#testTextFlaky3 failed 1 time(s)
		com.example.MainActivityFlakyTest#testTextFlaky4 failed 1 time(s)
		com.example.MainActivityFlakyTest#testTextFlaky5 failed 2 time(s)
		com.example.MainActivityFlakyTest#testTextFlaky7 failed 1 time(s)
Total time: 0H 0m 47s
I 18:19:09.936 [main] <c.m.m.e.BugsnagExceptionsReporter> Finish BugSnag
D 18:19:09.936 [main] <com.bugsnag.Bugsnag> Closing connection to Bugsnag
D 18:19:09.937 [Thread-2] <com.bugsnag.Bugsnag> Closing connection to Bugsnag
marathon v0.7.0: Test run failed
Process finished with exit code 1
```

The condition for expected tests == actual should account for test retries.
This is not trivial for tests that are discovered during the runtime, e.g. parameterized tests since they might be added multiple times due to retries.