### PR TITLE
Shuffle tests

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/FileConfiguration.kt
@@ -35,6 +35,7 @@ data class FileConfiguration(
 
     var testBatchTimeoutMillis: Long?,
     var testOutputTimeoutMillis: Long?,
+    var shuffleRunOrder: Boolean?,
     var debug: Boolean?,
 
     var vendorConfiguration: FileVendorConfiguration?,

--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/config/ConfigFactory.kt
@@ -62,6 +62,7 @@ class ConfigFactory(private val mapper: ObjectMapper) {
             excludeSerialRegexes = config.excludeSerialRegexes,
             testBatchTimeoutMillis = config.testBatchTimeoutMillis,
             testOutputTimeoutMillis = config.testOutputTimeoutMillis,
+            shuffleRunOrder = config.shuffleRunOrder,
             debug = config.debug,
             vendorConfiguration = vendorConfiguration as VendorConfiguration,
             analyticsTracking = config.analyticsTracking

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -340,6 +340,24 @@ object ConfigFactorySpec : Spek(
                 }
             }
 
+            on("configuration with no shuffleRunOrder") {
+                val file = File(ConfigFactorySpec::class.java.getResource("/fixture/config/sample_9.yaml").file)
+
+                it("should default to false") {
+                    val configuration = parser.create(file, mockEnvironmentReader())
+                    configuration.shuffleRunOrder shouldBe false
+                }
+            }
+
+            on("configuration with shuffleRunOrder") {
+                val file = File(ConfigFactorySpec::class.java.getResource("/fixture/config/sample_10.yaml").file)
+
+                it("should be true") {
+                    val configuration = parser.create(file, mockEnvironmentReader())
+                    configuration.shuffleRunOrder shouldBe true
+                }
+            }
+
             on("configuration time limits specified as Duration") {
                 val file =
                     File(ConfigFactorySpec::class.java.getResource("/fixture/config/sample_10.yaml").file)

--- a/cli/src/test/resources/fixture/config/sample_10.yaml
+++ b/cli/src/test/resources/fixture/config/sample_10.yaml
@@ -14,3 +14,4 @@ flakinessStrategy:
   minSuccessRate: 0.7
   maxCount: 3
   timeLimit: "-P30D"
+shuffleRunOrder: true

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -82,8 +82,13 @@ class Marathon(
         val deviceProvider = loadDeviceProvider(configuration.vendorConfiguration)
 
         configurationValidator.validate(configuration)
-
-        val parsedTests = testParser.extract(configuration)
+        val parsedTests = when(configuration.shuffleRunOrder) {
+            true -> {
+                log.info("Shuffling test run order.")
+                testParser.extract(configuration).shuffled()
+            }
+            else -> testParser.extract(configuration)
+        }
         val tests = applyTestFilters(parsedTests)
         val shard = prepareTestShard(tests, analytics)
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
@@ -12,15 +12,8 @@ import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.allure.AllureReporter
-import com.malinskiy.marathon.report.device.DeviceInfoJsonReporter
-import com.malinskiy.marathon.report.html.HtmlSummaryReporter
-import com.malinskiy.marathon.report.junit.JUnitReporter
-import com.malinskiy.marathon.report.junit.JUnitWriter
 import com.malinskiy.marathon.report.raw.RawJsonReporter
 import com.malinskiy.marathon.report.stdout.StdoutReporter
-import com.malinskiy.marathon.report.test.TestJsonReporter
-import com.malinskiy.marathon.report.timeline.TimelineReporter
-import com.malinskiy.marathon.report.timeline.TimelineSummaryProvider
 import com.malinskiy.marathon.time.Timer
 import java.io.File
 
@@ -63,13 +56,8 @@ internal class TrackerFactory(
     private fun createExecutionReportGenerator(): ExecutionReportGenerator {
         return ExecutionReportGenerator(
             listOf(
-                DeviceInfoJsonReporter(fileManager, gson),
-                JUnitReporter(JUnitWriter(fileManager)),
-                TimelineReporter(TimelineSummaryProvider(), gson, configuration.outputDir),
                 RawJsonReporter(fileManager, gson),
-                TestJsonReporter(fileManager, gson),
                 AllureReporter(configuration, File(configuration.outputDir, "allure-results")),
-                HtmlSummaryReporter(gson, configuration.outputDir, configuration),
                 StdoutReporter(timer)
             )
         )

--- a/core/src/main/kotlin/com/malinskiy/marathon/di/Modules.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/di/Modules.kt
@@ -29,7 +29,7 @@ val coreModule = module {
     single<Gson> { Gson() }
     single<Clock> { Clock.systemDefaultZone() }
     single<Timer> { SystemTimer(get()) }
-    single<ProgressReporter> { ProgressReporter() }
+    single<ProgressReporter> { ProgressReporter(get()) }
     single<Marathon> { Marathon(get(), get(), get(), get(), get()) }
 }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/Configuration.kt
@@ -43,6 +43,7 @@ data class Configuration constructor(
 
     val testBatchTimeoutMillis: Long,
     val testOutputTimeoutMillis: Long,
+    val shuffleRunOrder: Boolean,
     val debug: Boolean,
 
     val vendorConfiguration: VendorConfiguration,
@@ -75,6 +76,7 @@ data class Configuration constructor(
 
         testBatchTimeoutMillis: Long?,
         testOutputTimeoutMillis: Long?,
+        shuffleRunOrder: Boolean?,
         debug: Boolean?,
 
         vendorConfiguration: VendorConfiguration,
@@ -103,6 +105,7 @@ data class Configuration constructor(
                 excludeSerialRegexes = excludeSerialRegexes ?: emptyList(),
                 testBatchTimeoutMillis = testBatchTimeoutMillis ?: DEFAULT_EXECUTION_TIMEOUT_MILLIS,
                 testOutputTimeoutMillis = testOutputTimeoutMillis ?: DEFAULT_OUTPUT_TIMEOUT_MILLIS,
+                shuffleRunOrder = shuffleRunOrder ?: false,
                 debug = debug ?: true,
                 vendorConfiguration = vendorConfiguration,
                 analyticsTracking = analyticsTracking ?: false

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -111,9 +111,11 @@ class DeviceActor(
                 is DeviceAction.Terminate -> {
                     val batch = sideEffect.batch
                     if (batch == null) {
+                        logger.debug { "deviceAction batch == null terminate" }
                         terminate()
                     } else {
                         returnBatch(batch).invokeOnCompletion {
+                            logger.debug { "deviceAction batch != null terminate" }
                             terminate()
                         }
                     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporter.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.execution.progress
 
 import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.execution.progress.tracker.PoolProgressTracker
 import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.toTestName
@@ -10,11 +11,11 @@ import kotlin.math.roundToInt
 
 const val HUNDRED_PERCENT_IN_FLOAT: Float = 100.0f
 
-class ProgressReporter {
+class ProgressReporter(private val configuration: Configuration) {
     private val reporters = ConcurrentHashMap<DevicePoolId, PoolProgressTracker>()
 
     private inline fun <T> execute(poolId: DevicePoolId, f: (PoolProgressTracker) -> T): T {
-        val reporter = reporters[poolId] ?: PoolProgressTracker()
+        val reporter = reporters[poolId] ?: PoolProgressTracker(configuration)
         val result = f(reporter)
         reporters[poolId] = reporter
         return result

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTracker.kt
@@ -1,10 +1,11 @@
 package com.malinskiy.marathon.execution.progress.tracker
 
 import com.malinskiy.marathon.actor.StateMachine
+import com.malinskiy.marathon.execution.Configuration
 import com.malinskiy.marathon.test.Test
 import java.util.concurrent.atomic.AtomicInteger
 
-class PoolProgressTracker {
+class PoolProgressTracker(private val configuration: Configuration) {
 
     private val tests = mutableMapOf<Test, StateMachine<ProgressTestState, ProgressEvent, Any>>()
 
@@ -23,7 +24,11 @@ class PoolProgressTracker {
         }
         state<ProgressTestState.Passed> {
             on<ProgressEvent.Failed> {
-                dontTransition()
+                if (configuration.strictMode) {
+                    transitionTo(ProgressTestState.Failed)
+                } else {
+                    dontTransition()
+                }
             }
             on<ProgressEvent.Ignored> {
                 dontTransition()
@@ -31,7 +36,11 @@ class PoolProgressTracker {
         }
         state<ProgressTestState.Failed> {
             on<ProgressEvent.Passed> {
-                transitionTo(ProgressTestState.Passed)
+                if (configuration.strictMode) {
+                    dontTransition()
+                } else {
+                    transitionTo(ProgressTestState.Passed)
+                }
             }
         }
         state<ProgressTestState.Ignored> {

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -3,11 +3,11 @@ package com.malinskiy.marathon.io
 import com.malinskiy.marathon.device.DeviceInfo
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.test.Test
-import com.malinskiy.marathon.test.toTestName
 import java.io.File
 import java.nio.file.Files.createDirectories
 import java.nio.file.Path
 import java.nio.file.Paths.get
+import java.util.UUID
 
 @Suppress("TooManyFunctions")
 class FileManager(private val output: File) {
@@ -46,7 +46,7 @@ class FileManager(private val output: File) {
 
     private fun createFile(directory: Path, filename: String): File = File(directory.toFile(), filename)
 
-    private fun createFilename(test: Test, fileType: FileType): String = "${test.toTestName()}.${fileType.suffix}"
+    private fun createFilename(test: Test, fileType: FileType): String = "${UUID.randomUUID()}.${fileType.suffix}"
 
     private fun createFilename(device: DeviceInfo, fileType: FileType): String = "${device.serialNumber}.${fileType.suffix}"
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
@@ -109,7 +109,7 @@ class AllureReporter(val configuration: Configuration, private val outputDirecto
     }
 
     private fun getHistoryId(test: Test) =
-        ResultsUtils.generateMethodSignatureHash(test.clazz, test.method, emptyList())
+        ResultsUtils.generateMethodSignatureHash(test.clazz, test.method, listOf(test.pkg))
 
     private fun Test.getOptionalLabels(): Collection<Label> {
         val list = mutableListOf<Label>()

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/ProgressReporterSpek.kt
@@ -2,17 +2,46 @@ package com.malinskiy.marathon.execution.progress
 
 import com.malinskiy.marathon.device.DevicePoolId
 import com.malinskiy.marathon.device.toDeviceInfo
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.test.Mocks
 import com.malinskiy.marathon.test.StubDevice
+import com.malinskiy.marathon.test.StubDeviceProvider
 import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.TestVendorConfiguration
 import org.amshove.kluent.shouldEqualTo
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import java.io.File
 
 class ProgressReporterSpek : Spek(
     {
         describe("ProgressReporter") {
-            val reporter = ProgressReporter()
+            val reporter = ProgressReporter(Configuration(
+                name = "",
+                outputDir = File(""),
+                analyticsConfiguration = null,
+                poolingStrategy = null,
+                shardingStrategy = null,
+                sortingStrategy = null,
+                batchingStrategy = null,
+                flakinessStrategy = null,
+                retryStrategy = null,
+                filteringConfiguration = null,
+                ignoreFailures = null,
+                isCodeCoverageEnabled = null,
+                fallbackToScreenshots = null,
+                strictMode = null,
+                uncompletedTestRetryQuota = null,
+                testClassRegexes = null,
+                includeSerialRegexes = null,
+                excludeSerialRegexes = null,
+                testBatchTimeoutMillis = null,
+                testOutputTimeoutMillis = null,
+                debug = false,
+                vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
+                analyticsTracking = false
+            ))
             val deviceInfo = StubDevice().toDeviceInfo()
 
             it("should report proper progress for one pool") {

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerSpek.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/progress/tracker/PoolProgressTrackerSpek.kt
@@ -1,0 +1,87 @@
+package com.malinskiy.marathon.execution.progress.tracker
+
+import com.malinskiy.marathon.execution.Configuration
+import com.malinskiy.marathon.test.Mocks
+import com.malinskiy.marathon.test.StubDeviceProvider
+import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.TestVendorConfiguration
+import org.amshove.kluent.shouldEqualTo
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import java.io.File
+
+class PoolProgressTrackerSpek : Spek(
+    {
+        val test = Test(
+            pkg = "com.malinskiy.marathon",
+            clazz = "SomeTest",
+            method = "someMethod",
+            metaProperties = emptyList()
+        )
+
+        fun createConfiguration(strictMode: Boolean): Configuration {
+            return Configuration(
+                name = "",
+                outputDir = File(""),
+                analyticsConfiguration = null,
+                poolingStrategy = null,
+                shardingStrategy = null,
+                sortingStrategy = null,
+                batchingStrategy = null,
+                flakinessStrategy = null,
+                retryStrategy = null,
+                filteringConfiguration = null,
+                ignoreFailures = null,
+                isCodeCoverageEnabled = null,
+                fallbackToScreenshots = null,
+                strictMode = strictMode,
+                uncompletedTestRetryQuota = null,
+                testClassRegexes = null,
+                includeSerialRegexes = null,
+                excludeSerialRegexes = null,
+                testBatchTimeoutMillis = null,
+                testOutputTimeoutMillis = null,
+                debug = false,
+                vendorConfiguration = TestVendorConfiguration(Mocks.TestParser.DEFAULT, StubDeviceProvider()),
+                analyticsTracking = false
+            )
+        }
+
+        given("Configuration strictMode false") {
+            val unit = PoolProgressTracker(createConfiguration(strictMode = false))
+            on("Test started, passed and then failed") {
+                unit.testStarted(test)
+                unit.testPassed(test)
+                unit.testFailed(test)
+                it("Produces true") {
+                    unit.aggregateResult().shouldEqualTo(true)
+                }
+            }
+            on("Test passed again") {
+                unit.testPassed(test)
+                it("Produces true") {
+                    unit.aggregateResult().shouldEqualTo(true)
+                }
+            }
+        }
+
+        given("Configuration strictMode true") {
+            val unit = PoolProgressTracker(createConfiguration(strictMode = true))
+            on("Test started, passed and then failed") {
+                unit.testStarted(test)
+                unit.testPassed(test)
+                unit.testFailed(test)
+                it("Produces false") {
+                    unit.aggregateResult().shouldEqualTo(false)
+                }
+            }
+            on("Test passed again") {
+                unit.testPassed(test)
+                it("Produces false") {
+                    unit.aggregateResult().shouldEqualTo(false)
+                }
+            }
+        }
+    })


### PR DESCRIPTION
Add ability to shuffle test run order. New optional configuration key, shuffleRunOrder, defaults to false if it is not defined in marathon file. To shuffle test run order, include shuffleRunOrder: true in marathon file