### PR TITLE
feat(android): multiple adb servers

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.malinskiy.marathon.config.exceptions.ConfigurationException
+import com.malinskiy.marathon.config.vendor.android.AdbEndpoint
 import com.malinskiy.marathon.config.vendor.android.AllureConfiguration
 import com.malinskiy.marathon.config.vendor.android.AndroidTestBundleConfiguration
 import com.malinskiy.marathon.config.vendor.android.FileSyncConfiguration
@@ -54,6 +55,7 @@ sealed class VendorConfiguration {
         @JsonProperty("threadingConfiguration") val threadingConfiguration: ThreadingConfiguration = ThreadingConfiguration(),
         @JsonProperty("testParserConfiguration") val testParserConfiguration: TestParserConfiguration = TestParserConfiguration.LocalTestParserConfiguration,
         @JsonProperty("testAccessConfiguration") val testAccessConfiguration: TestAccessConfiguration = TestAccessConfiguration(),
+        @JsonProperty("adbServers") val adbServers: List<AdbEndpoint> = listOf(AdbEndpoint())
     ) : VendorConfiguration() {
         fun safeAndroidSdk(): File = androidSdk ?: throw ConfigurationException("No android SDK path specified")
 

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/android/AdbEndpoint.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/android/AdbEndpoint.kt
@@ -1,0 +1,6 @@
+package com.malinskiy.marathon.config.vendor.android
+
+data class AdbEndpoint(
+    val host: String = "127.0.0.1",
+    val port: Int = 5037,
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/external/graphite/GraphiteTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/external/graphite/GraphiteTracker.kt
@@ -44,7 +44,7 @@ class GraphiteTracker(
     private fun getBaseMetricName(test: Test, device: DeviceInfo): String {
         val testName = test.toSafeTestName().replaceDots()
         val testPackage = test.pkg.replaceDots()
-        return "tests.$testName.$testPackage.${test.clazz}.${test.method}.${device.serialNumber}"
+        return "tests.$testName.$testPackage.${test.clazz}.${test.method}.${device.safeSerialNumber}"
     }
 
     private fun String.replaceDots() = replace(".", "--")

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/external/influx/InfluxDbTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/external/influx/InfluxDbTracker.kt
@@ -29,7 +29,7 @@ class InfluxDbTracker(
                     .tag("package", testResult.test.pkg)
                     .tag("class", testResult.test.clazz)
                     .tag("method", testResult.test.method)
-                    .tag("deviceSerial", device.serialNumber)
+                    .tag("deviceSerial", device.safeSerialNumber)
                     .addField("ignored", if (testResult.isIgnored) 1.0 else 0.0)
                     .addField("success", if (testResult.status == TestStatus.PASSED) 1.0 else 0.0)
                     .addField("duration", testResult.durationMillis())

--- a/core/src/main/kotlin/com/malinskiy/marathon/device/DeviceInfo.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/device/DeviceInfo.kt
@@ -1,5 +1,7 @@
 package com.malinskiy.marathon.device
 
+import com.malinskiy.marathon.extension.escape
+
 data class DeviceInfo(
     val operatingSystem: OperatingSystem,
     val serialNumber: String,
@@ -8,7 +10,9 @@ data class DeviceInfo(
     val networkState: NetworkState,
     val deviceFeatures: Collection<DeviceFeature>,
     val healthy: Boolean
-)
+) {
+    val safeSerialNumber: String by lazy { serialNumber.escape() }
+}
 
 fun Device.toDeviceInfo() = DeviceInfo(
     operatingSystem = operatingSystem,

--- a/core/src/main/kotlin/com/malinskiy/marathon/extension/StringExtensions.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/extension/StringExtensions.kt
@@ -24,5 +24,7 @@ object MD5 {
 }
 
 fun String.escape(): String {
-    return replace(regex = "[^a-zA-Z0-9\\.\\#]".toRegex(), "-")
+    return replace(regex = escapeRegex, "-")
 }
+
+val escapeRegex = "[^a-zA-Z0-9\\.\\#]".toRegex()

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileManager.kt
@@ -35,13 +35,13 @@ class FileManager(private val output: File) {
 
     fun createFolder(folderType: FolderType): File = createDirectories(get(output.absolutePath, folderType.dir)).toFile()
     fun createFolder(folderType: FolderType, pool: DevicePoolId, device: DeviceInfo): File =
-        createDirectories(get(output.absolutePath, folderType.dir, pool.name, device.serialNumber)).toFile()
+        createDirectories(get(output.absolutePath, folderType.dir, pool.name, device.safeSerialNumber)).toFile()
 
     fun createFolder(folderType: FolderType, pool: DevicePoolId): File =
         createDirectories(get(output.absolutePath, folderType.dir, pool.name)).toFile()
 
     fun createFolder(folderType: FolderType, device: DeviceInfo): File =
-        createDirectories(get(output.absolutePath, folderType.dir, device.serialNumber)).toFile()
+        createDirectories(get(output.absolutePath, folderType.dir, device.safeSerialNumber)).toFile()
 
     fun createTestResultFile(filename: String): File {
         val resultsFolder = get(output.absolutePath, FileType.TEST_RESULT.dir).toFile()
@@ -56,7 +56,7 @@ class FileManager(private val output: File) {
         createDirectories(getDirectory(fileType, pool))
 
     private fun getDirectory(fileType: FileType, pool: DevicePoolId, device: DeviceInfo): Path =
-        getDirectory(fileType, pool, device.serialNumber)
+        getDirectory(fileType, pool, device.safeSerialNumber)
 
     private fun getDirectory(fileType: FileType, pool: DevicePoolId, serial: String): Path =
         get(output.absolutePath, fileType.dir, pool.name, serial)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/html/HtmlSummaryReporter.kt
@@ -94,7 +94,7 @@ class HtmlSummaryReporter(
                     .replace("\${date}", formattedDate)
             )
 
-            pool.tests.map { it to File(File(poolsDir, pool.poolId.name), it.device.serialNumber).apply { mkdirs() } }
+            pool.tests.map { it to File(File(poolsDir, pool.poolId.name), it.device.safeSerialNumber).apply { mkdirs() } }
                 .map { (test, testDir) ->
                     Triple(
                         test,
@@ -160,7 +160,7 @@ class HtmlSummaryReporter(
     fun DeviceInfo.toHtmlDevice() = HtmlDevice(
         apiLevel = operatingSystem.version,
         isTablet = false,
-        serial = serialNumber,
+        serial = safeSerialNumber,
         modelName = model
     )
 
@@ -203,7 +203,7 @@ class HtmlSummaryReporter(
         name = test.method,
         durationMillis = durationMillis(),
         status = status.toHtmlStatus(),
-        deviceId = this.device.serialNumber,
+        deviceId = this.device.safeSerialNumber,
         diagnosticVideo = device.deviceFeatures.contains(DeviceFeature.VIDEO),
         diagnosticScreenshots = device.deviceFeatures.contains(DeviceFeature.SCREENSHOT),
         stacktrace = stacktrace,
@@ -266,7 +266,7 @@ class HtmlSummaryReporter(
         name = test.method,
         durationMillis = durationMillis(),
         status = status.toHtmlStatus(),
-        deviceId = this.device.serialNumber
+        deviceId = this.device.safeSerialNumber
     )
 
     fun toHtmlTestLogDetails(

--- a/docs/_posts/2018-11-19-android.md
+++ b/docs/_posts/2018-11-19-android.md
@@ -674,11 +674,14 @@ marathon {
 
 ## Multiple adb servers
 Default configuration of marathon assumes that adb server is started locally and is available at `127.0.0.1:5037`. In some cases it may be
-desirable to connect multiple adb servers instead of connection devices to one adb servers. An example of this is distributed execution of
-tests using test access (calling adb commands from tests). For such scenario all emulators should be connected via a local adb server. 
-Default port for each host is 5037.
+desirable to connect multiple adb servers instead of connecting devices to a single adb server. An example of this is distributed execution 
+of tests using test access (calling adb commands from tests). For such scenario all emulators should be connected via a local (in relation 
+to the emulator) adb server. Default port for each host is 5037.
 
-This functionality is only supported by adam because ddmlib doesn't support connecting to a remote instance of adb server.
+In order to expose the adb server it should be started on all or public network interfaces using option `-a`. For example, if you want to
+expose the adb server and start it in foreground explicitly on port 5037: `adb nodaemon server -a -P 5037`.
+
+This functionality is only supported by vendor adam because ddmlib doesn't support connecting to a remote instance of adb server.
 
 {% tabs adb-servers %} {% tab adb-servers Marathonfile %}
 

--- a/docs/_posts/2018-11-19-android.md
+++ b/docs/_posts/2018-11-19-android.md
@@ -645,7 +645,7 @@ Marathon supports adam's junit extensions which allow tests to gain access to ad
 [docs](https://malinskiy.github.io/adam/extensions/1-android-junit/) as well as the [PR](https://github.com/Malinskiy/adam/pull/30) for
 description on how this works.
 
-{% tabs file-sync %} {% tab file-sync Marathonfile %}
+{% tabs test-access %} {% tab test-access Marathonfile %}
 
 ```yaml
 vendorConfiguration:
@@ -657,7 +657,7 @@ vendorConfiguration:
     consoleToken: "cantFoolMe"
 ```
 
-{% endtab %} {% tab file-sync Gradle Kotlin %}
+{% endtab %} {% tab test-access Gradle Kotlin %}
 
 ```kotlin
 marathon {
@@ -666,6 +666,38 @@ marathon {
     grpc = true,
     console = true,
     consoleToken = "cantFoolMe"
+  )
+}
+```
+
+{% endtab %} {% endtabs %}
+
+## Multiple adb servers
+Default configuration of marathon assumes that adb server is started locally and is available at `127.0.0.1:5037`. In some cases it may be
+desirable to connect multiple adb servers instead of connection devices to one adb servers. An example of this is distributed execution of
+tests using test access (calling adb commands from tests). For such scenario all emulators should be connected via a local adb server. 
+Default port for each host is 5037.
+
+This functionality is only supported by adam because ddmlib doesn't support connecting to a remote instance of adb server.
+
+{% tabs adb-servers %} {% tab adb-servers Marathonfile %}
+
+```yaml
+vendorConfiguration:
+  type: "Android"
+  adbServers:
+    - host: 127.0.0.1
+    - host: 10.0.0.2
+      port: 5037
+```
+
+{% endtab %} {% tab adb-servers Gradle Kotlin %}
+
+```kotlin
+marathon {
+  adbServers = listOf(
+    AdbEndpoint(host = "127.0.0.1"),
+    AdbEndpoint(host = "10.0.0.2", port = 5037)
   )
 }
 ```

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -127,7 +127,7 @@ additional parameters might not be supported by all vendor modules. If you find 
 vendor module at fault.
 
 * TOC
-* {:toc}
+{:toc}
 
 # General parameters
 

--- a/docs/_posts/2018-11-19-configuration.md
+++ b/docs/_posts/2018-11-19-configuration.md
@@ -116,9 +116,7 @@ marathon {
 }
 ```
 
-### File paths in configuration
-
-When specifying relative host file paths in the configuration they will be resolved relative to the directory of the Marathonfile, e.g. if
+When specifying **relative host file** paths in the configuration they will be resolved relative to the directory of the Marathonfile, e.g. if
 you have `/home/user/app/Marathonfile` with `baseOutputDir = "./output"` then the actual path to the output directory will
 be `/home/user/app/output`.
 

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonExtension.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonExtension.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.gradle
 
 import com.malinskiy.marathon.config.ScreenRecordingPolicy
 import com.malinskiy.marathon.config.vendor.VendorConfiguration
+import com.malinskiy.marathon.config.vendor.android.AdbEndpoint
 import com.malinskiy.marathon.config.vendor.android.AllureConfiguration
 import com.malinskiy.marathon.config.vendor.android.FileSyncConfiguration
 import com.malinskiy.marathon.config.vendor.android.ScreenRecordConfiguration
@@ -70,6 +71,8 @@ open class MarathonExtension(project: Project) {
     var instrumentationArgs: MutableMap<String, String> = mutableMapOf()
 
     var testAccessConfiguration: TestAccessConfiguration? = null
+
+    var adbServers: List<AdbEndpoint>? = null
 
     //Kotlin way
     fun analytics(block: AnalyticsConfig.() -> Unit) {

--- a/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonRunTask.kt
+++ b/marathon-gradle-plugin/src/main/kotlin/com/malinskiy/marathon/gradle/MarathonRunTask.kt
@@ -10,6 +10,7 @@ import com.malinskiy.marathon.config.vendor.DEFAULT_INIT_TIMEOUT_MILLIS
 import com.malinskiy.marathon.config.vendor.DEFAULT_INSTALL_OPTIONS
 import com.malinskiy.marathon.config.vendor.DEFAULT_WAIT_FOR_DEVICES_TIMEOUT
 import com.malinskiy.marathon.config.vendor.VendorConfiguration
+import com.malinskiy.marathon.config.vendor.android.AdbEndpoint
 import com.malinskiy.marathon.config.vendor.android.AllureConfiguration
 import com.malinskiy.marathon.config.vendor.android.FileSyncConfiguration
 import com.malinskiy.marathon.config.vendor.android.ScreenRecordConfiguration
@@ -139,7 +140,8 @@ open class MarathonRunTask @Inject constructor(objects: ObjectFactory) : Abstrac
             allureConfiguration = allureConfiguration,
             fileSyncConfiguration = extension.fileSyncConfiguration ?: FileSyncConfiguration(),
             testParserConfiguration = extension.testParserConfiguration ?: TestParserConfiguration.LocalTestParserConfiguration,
-            testAccessConfiguration = extension.testAccessConfiguration ?: TestAccessConfiguration()
+            testAccessConfiguration = extension.testAccessConfiguration ?: TestAccessConfiguration(),
+            adbServers = extension.adbServers ?: listOf(AdbEndpoint())
         )
     }
 

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamAndroidDevice.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamAndroidDevice.kt
@@ -90,10 +90,10 @@ class AdamAndroidDevice(
     override val serialNumber: String
         get() = when {
             booted -> realSerialNumber
-            else -> "${client.host}:${client.port}:$adbSerial"
+            else -> "${client.host.hostAddress}:${client.port}:$adbSerial"
         }
 
-    override suspend fun detectRealSerialNumber() = "${client.host}:${client.port}:${super.detectRealSerialNumber()}"
+    override suspend fun detectRealSerialNumber() = "${client.host.hostAddress}:${client.port}:${super.detectRealSerialNumber()}"
 
     override suspend fun setup() {
         withContext(coroutineContext) {
@@ -107,7 +107,7 @@ class AdamAndroidDevice(
     }
 
     private val dispatcher by lazy {
-        newFixedThreadPoolContext(2, "AndroidDevice - execution - ${client.host}:${client.port}:${adbSerial}")
+        newFixedThreadPoolContext(2, "AndroidDevice - execution - ${client.host.hostAddress}:${client.port}:${adbSerial}")
     }
     override val coroutineContext: CoroutineContext = dispatcher
 

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
@@ -7,10 +7,10 @@ import com.malinskiy.adam.request.device.AsyncDeviceMonitorRequest
 import com.malinskiy.adam.request.device.Device
 import com.malinskiy.adam.request.device.ListDevicesRequest
 import com.malinskiy.adam.request.misc.GetAdbServerVersionRequest
+import com.malinskiy.adam.transport.vertx.VertxSocketFactory
 import com.malinskiy.marathon.actor.unboundedChannel
 import com.malinskiy.marathon.analytics.internal.pub.Track
 import com.malinskiy.marathon.android.AndroidTestBundleIdentifier
-import com.malinskiy.marathon.android.exception.AdbStartException
 import com.malinskiy.marathon.config.Configuration
 import com.malinskiy.marathon.config.vendor.VendorConfiguration
 import com.malinskiy.marathon.device.DeviceProvider
@@ -24,6 +24,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -32,6 +34,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.ConnectException
+import java.net.InetAddress
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 
@@ -60,33 +63,57 @@ class AdamDeviceProvider(
 
     override val deviceInitializationTimeoutMillis: Long = configuration.deviceInitializationTimeoutMillis
 
-    private lateinit var client: AndroidDebugBridgeClient
-    private lateinit var logcatManager: LogcatManager
-    private lateinit var deviceEventsChannel: ReceiveChannel<List<Device>>
+    private lateinit var clients: List<AndroidDebugBridgeClient>
+    private val socketFactory = VertxSocketFactory(idleTimeout = vendorConfiguration.timeoutConfiguration.socketIdleTimeout.toMillis())
+    private val logcatManager: LogcatManager = LogcatManager()
+    private lateinit var deviceEventsChannel: ReceiveChannel<Pair<AndroidDebugBridgeClient, List<Device>>>
     private val deviceEventsChannelMutex = Mutex()
-    private val deviceStateTracker = DeviceStateTracker()
+    private val multiServerDeviceStateTracker = MultiServerDeviceStateTracker()
 
+    private suspend fun AndroidDebugBridgeClient.isConnectable(): Boolean {
+        try {
+            printAdbServerVersion(this)
+            return true
+        } catch (e: ConnectException) {
+            if (host.isLoopbackAddress) {
+                //For local adb server we try to start it if it's not reachable
+                val success = StartAdbInteractor().execute(androidHome = vendorConfiguration.androidSdk, serverPort = port)
+                if (!success) {
+                    return false
+                }
+                return try {
+                    printAdbServerVersion(this)
+                    true
+                } catch (e: ConnectException) {
+                    false
+                }
+            } else {
+                return false
+            }
+        }
+    }
 
     override suspend fun initialize() {
-        client = AndroidDebugBridgeClientFactory().apply {
-            coroutineContext = adbCommunicationContext
-            idleTimeout = vendorConfiguration.timeoutConfiguration.socketIdleTimeout
-        }.build()
-        logcatManager = LogcatManager(client)
-
-        try {
-            printAdbServerVersion()
-        } catch (e: ConnectException) {
-            val success = StartAdbInteractor().execute(androidHome = vendorConfiguration.androidSdk)
-            if (!success) {
-
-                throw AdbStartException()
+        clients = vendorConfiguration.adbServers.map {
+            AndroidDebugBridgeClientFactory().apply {
+                host = InetAddress.getByName(it.host)
+                port = it.port
+                socketFactory = socketFactory
+            }.build()
+        }.filter {
+            val connectable = it.isConnectable()
+            if (!connectable) {
+                logger.error { "adb server ${it.host}:${it.port} is unavailable" }
             }
-            printAdbServerVersion()
+            connectable
+        }
+
+        if (clients.isEmpty()) {
+            throw NoDevicesException("All adb servers are unavailable")
         }
 
         withTimeoutOrNull(vendorConfiguration.waitForDevicesTimeoutMillis) {
-            while (client.execute(ListDevicesRequest()).isEmpty()) {
+            while (clients.flatMap { it.execute(ListDevicesRequest()) }.isEmpty()) {
                 delay(DEFAULT_WAIT_FOR_DEVICES_SLEEP_TIME)
             }
         } ?: throw NoDevicesException("No devices found")
@@ -97,10 +124,17 @@ class AdamDeviceProvider(
              */
             while (isActive) {
                 deviceEventsChannelMutex.withLock {
-                    deviceEventsChannel = client.execute(AsyncDeviceMonitorRequest(), this)
+                    deviceEventsChannel = produce {
+                        clients.forEach { client ->
+                            val deviceChannel = client.execute(AsyncDeviceMonitorRequest(), this)
+                            launch {
+                                deviceChannel.consumeEach { send(Pair(client, it)) }
+                            }
+                        }
+                    }
                 }
-                for (currentDeviceList in deviceEventsChannel) {
-                    deviceStateTracker.update(currentDeviceList).forEach { update ->
+                for ((client, currentDeviceList) in deviceEventsChannel) {
+                    multiServerDeviceStateTracker.update(client, currentDeviceList).forEach { update ->
                         val serial = update.first
                         val state = update.second
                         when (state) {
@@ -108,7 +142,7 @@ class AdamDeviceProvider(
                                 val device =
                                     AdamAndroidDevice(
                                         client,
-                                        deviceStateTracker,
+                                        multiServerDeviceStateTracker.getTracker(client),
                                         logcatManager,
                                         testBundleIdentifier,
                                         serial,
@@ -144,9 +178,9 @@ class AdamDeviceProvider(
         }
     }
 
-    private suspend fun printAdbServerVersion() {
+    private suspend fun printAdbServerVersion(client: AndroidDebugBridgeClient) {
         val adbVersion = client.execute(GetAdbServerVersionRequest())
-        logger.debug { "Android Debug Bridge version $adbVersion" }
+        logger.debug { "Android Debug Bridge ${client.host}:${client.port}: version $adbVersion" }
     }
 
     override suspend fun terminate() {
@@ -158,7 +192,7 @@ class AdamDeviceProvider(
             deviceEventsChannel.cancel()
         }
         logcatManager.close()
-        client.socketFactory.close()
+        socketFactory.close()
     }
 
     override fun subscribe() = channel

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/DeviceStateTracker.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/DeviceStateTracker.kt
@@ -1,8 +1,25 @@
 package com.malinskiy.marathon.android.adam
 
+import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.device.Device
 import com.malinskiy.adam.request.device.DeviceState
 import java.util.concurrent.ConcurrentHashMap
+
+class MultiServerDeviceStateTracker {
+    private val clients: ConcurrentHashMap<String, DeviceStateTracker> = ConcurrentHashMap()
+
+    fun update(client: AndroidDebugBridgeClient, updatedDevices: List<Device>): List<Pair<String, TrackingUpdate>> {
+        val tracker = clients[client.id()] ?: DeviceStateTracker()
+        clients[client.id()] = tracker
+
+        return tracker.update(updatedDevices)
+    }
+
+    private fun AndroidDebugBridgeClient.id() = "$host:$port"
+
+    fun getTracker(client: AndroidDebugBridgeClient) =
+        clients[client.id()] ?: throw RuntimeException("Client ${client.id()} not registered for device tracking")
+}
 
 class DeviceStateTracker {
     private val devices: ConcurrentHashMap<String, DeviceState> = ConcurrentHashMap()

--- a/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/LogcatManager.kt
+++ b/vendor/vendor-android/adam/src/main/kotlin/com/malinskiy/marathon/android/adam/LogcatManager.kt
@@ -1,6 +1,5 @@
 package com.malinskiy.marathon.android.adam
 
-import com.malinskiy.adam.AndroidDebugBridgeClient
 import com.malinskiy.adam.request.logcat.ChanneledLogcatRequest
 import com.malinskiy.adam.request.logcat.LogcatReadMode
 import com.malinskiy.marathon.android.adam.log.LogCatMessageParser
@@ -12,7 +11,7 @@ import kotlinx.coroutines.supervisorScope
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.CoroutineContext
 
-class LogcatManager(private val client: AndroidDebugBridgeClient) : CoroutineScope {
+class LogcatManager : CoroutineScope {
     private val dispatcher = newFixedThreadPoolContext(4, "LogcatManager")
     override val coroutineContext: CoroutineContext
         get() = dispatcher
@@ -26,7 +25,7 @@ class LogcatManager(private val client: AndroidDebugBridgeClient) : CoroutineSco
     fun subscribe(device: AdamAndroidDevice) {
         devices[device] = launch {
             supervisorScope {
-                val logcatChannel = client.execute(
+                val logcatChannel = device.client.execute(
                     ChanneledLogcatRequest(
                         modes = listOf(LogcatReadMode.long)
                     ), serial = device.adbSerial, scope = this

--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -137,7 +137,7 @@ abstract class BaseAndroidDevice(
     /**
      * We can only do this after the device finished booting
      */
-    private suspend fun detectRealSerialNumber(): String {
+    protected open suspend fun detectRealSerialNumber(): String {
         val marathonSerialProp: String = getProperty("marathon.serialno") ?: ""
         val serialProp: String = getProperty("ro.boot.serialno") ?: ""
         val hostName: String = getProperty("net.hostname") ?: ""

--- a/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
+++ b/vendor/vendor-android/ddmlib/src/main/kotlin/com/malinskiy/marathon/android/ddmlib/DdmlibDeviceProvider.kt
@@ -11,6 +11,7 @@ import com.malinskiy.marathon.analytics.internal.pub.Track
 import com.malinskiy.marathon.android.AndroidTestBundleIdentifier
 import com.malinskiy.marathon.config.Configuration
 import com.malinskiy.marathon.config.vendor.VendorConfiguration
+import com.malinskiy.marathon.config.vendor.android.AdbEndpoint
 import com.malinskiy.marathon.device.DeviceProvider
 import com.malinskiy.marathon.device.DeviceProvider.DeviceEvent.DeviceConnected
 import com.malinskiy.marathon.device.DeviceProvider.DeviceEvent.DeviceDisconnected
@@ -56,9 +57,18 @@ class DdmlibDeviceProvider(
                 "\tMore info: https://marathonlabs.github.io/marathon/ven/android.html#vendor-module-selection"
         }
 
+        /**
+         * Ddmlib supports only customizing port on the localhost server
+         */
+        if (vendorConfiguration.adbServers.size != 1 || vendorConfiguration.adbServers.first().host != AdbEndpoint().host) {
+            throw RuntimeException("ddmlib Android vendor supports only local adb server")
+        }
+
         DdmPreferences.setTimeOut(DEFAULT_DDM_LIB_TIMEOUT)
+        val endpoint = vendorConfiguration.adbServers.first()
+
         val adbInitOptions = AdbInitOptions.Builder()
-            .enableUserManagedAdbMode(5037)
+            .enableUserManagedAdbMode(endpoint.port)
             .setClientSupportEnabled(false)
             .build()
         AndroidDebugBridge.init(adbInitOptions)


### PR DESCRIPTION
This PR adds support for connecting multiple adb servers to the test run.

In order to expose the adb server it should be binded to public interface, e.g. `adb nodaemon server -a -P 5037`

Configuration now accepts the following:
```yaml
vendorConfiguration:
  type: "Android"
  adbServers:
    - host: 127.0.0.1
    - host: 10.0.0.2
      port: 5037
```
Default port for any host is assumed to be 5037.

It is user's responsibility not to provide the same host using multiple IPs.

All existing functionality works out-of-the-box: scaling device events are propagated, e.g. connect/disconnect

Main motivation for this feature is the test access to allow parallelising tests that require access to adb or emulator console ports.

Sample report:

![image](https://user-images.githubusercontent.com/2089114/139568100-0a5c941f-0e4a-4e15-b024-f4a1f823c12b.png)


TBD: serial number is changed to full one including the remote adb server's IP. Anything needs to be done for migrating metrics?