### PR TITLE
Provide name to allure result for allure-test-ops

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/allure/AllureReporter.kt
@@ -65,6 +65,7 @@ class AllureReporter(val configuration: Configuration, private val outputDirecto
     private fun createTestResult(uuid: String, device: DeviceInfo, testResult: TestResult): io.qameta.allure.model.TestResult {
         val test = testResult.test
         val fullName = test.toSimpleSafeTestName()
+        val testMethodName = test.method
         val suite = "${test.pkg}.${test.clazz}"
 
         val status: Status = when (testResult.status) {
@@ -86,6 +87,7 @@ class AllureReporter(val configuration: Configuration, private val outputDirecto
         val allureTestResult = io.qameta.allure.model.TestResult()
             .setUuid(uuid)
             .setFullName(fullName)
+            .setName(testMethodName)
             .setHistoryId(getHistoryId(test))
             .setStatus(status)
             .setStart(testResult.startTime)


### PR DESCRIPTION
[Allure test-ops](https://qameta.io/) is next gen of allure report.
Current marathon allure report in test-ops do not contains test names. All tests names is **Unknown**

![image](https://user-images.githubusercontent.com/1678579/145035092-48873da1-c924-40e4-b0de-053e8eb81ded.png)

After adding name to allure test results 

![image](https://user-images.githubusercontent.com/1678579/145037102-1a29343e-803c-4d8e-a8f3-a0cc092d3faf.png)
