### PR TITLE
fix(android): moving scoped storage folders requires creating the tar…

### DIFF
--- a/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/filesync/FileSyncTestRunListener.kt
+++ b/vendor/vendor-android/base/src/main/kotlin/com/malinskiy/marathon/android/executor/listeners/filesync/FileSyncTestRunListener.kt
@@ -99,6 +99,6 @@ class FileSyncTestRunListener(
      * Depends on tar for folder moving
      */
     private suspend fun moveScopedFolder(from: String, to: String, pkg: String) {
-        device.safeExecuteShellCommand("run-as $pkg sh -c 'cd $from && tar cf - .' | tar xvf - -C $to && run-as $pkg rm -R $from")
+        device.safeExecuteShellCommand("mkdir -p $to && run-as $pkg sh -c 'cd $from && tar cf - .' | tar xvf - -C $to && run-as $pkg rm -R $from")
     }
 }


### PR DESCRIPTION
…get folder first

tar -C doesn't actually create nested directory structures