### PR TITLE
feat(core): improve shutdown behaviour

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     val coroutines = "1.5.2"
 
     val ddmlib = "30.0.2"
-    val adam = "0.4.4"
+    val adam = "0.4.5"
     val dexTestParser = "2.3.3"
     val kotlinLogging = "2.1.21"
     val logbackClassic = "1.2.10"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    val marathon = System.getenv("GIT_TAG_NAME") ?: "0.7.0"
+    val marathon = System.getenv("GIT_TAG_NAME") ?: "0.7.2"
 
     val kotlin = "1.5.21"
     val coroutines = "1.5.2"

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -106,11 +106,11 @@ class Marathon(
             scheduler.execute()
         }
 
-        onFinish(analytics, deviceProvider)
+        val result = onFinish(analytics, deviceProvider)
         hook.uninstall()
 
         stopKoin()
-        return progressReporter.aggregateResult()
+        return result
     }
 
     private fun logSystemInformation() {
@@ -133,10 +133,11 @@ class Marathon(
         return shutdownHook
     }
 
-    private suspend fun onFinish(analytics: Analytics, deviceProvider: DeviceProvider) {
+    private suspend fun onFinish(analytics: Analytics, deviceProvider: DeviceProvider): Boolean {
         analytics.close()
         deviceProvider.terminate()
         tracker.close()
+        return progressReporter.aggregateResult()
     }
 
     private fun applyTestFilters(parsedTests: List<Test>): List<Test> {

--- a/sample/android-app/app/build.gradle.kts
+++ b/sample/android-app/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("marathon") version "0.7.0-SNAPSHOT"
+    id("marathon") version "0.7.2-SNAPSHOT"
 }
 
 android {

--- a/sample/android-library/library/build.gradle.kts
+++ b/sample/android-library/library/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("marathon") version "0.7.0-SNAPSHOT"
+    id("marathon") version "0.7.2-SNAPSHOT"
 }
 
 android {


### PR DESCRIPTION
Relates to https://github.com/Malinskiy/adam/pull/80 and fixes

```
Exception in thread "Thread-9" java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
	at java.base/java.lang.Runtime.addShutdownHook(Runtime.java:216)
	at io.vertx.core.file.impl.FileCache.registerShutdownHook(FileCache.java:79)
	at io.vertx.core.file.impl.FileCache.setupCache(FileCache.java:32)
	at io.vertx.core.file.impl.FileResolverImpl.<init>(FileResolverImpl.java:66)
	at io.vertx.core.impl.VertxBuilder.initFileResolver(VertxBuilder.java:334)
	at io.vertx.core.impl.VertxBuilder.init(VertxBuilder.java:274)
	at io.vertx.core.Vertx.vertx(Vertx.java:86)
	at io.vertx.core.Vertx.vertx(Vertx.java:76)
	at com.malinskiy.adam.transport.vertx.VertxSocketFactory$vertx$2.invoke(VertxSocketFactory.kt:31)
	at com.malinskiy.adam.transport.vertx.VertxSocketFactory$vertx$2.invoke(VertxSocketFactory.kt:31)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.malinskiy.adam.transport.vertx.VertxSocketFactory.getVertx(VertxSocketFactory.kt:31)
	at com.malinskiy.adam.transport.vertx.VertxSocketFactory.close(VertxSocketFactory.kt:44)
	at com.malinskiy.marathon.android.adam.AdamDeviceProvider.terminate(AdamDeviceProvider.kt:195)
	at com.malinskiy.marathon.Marathon.onFinish(Marathon.kt:138)
	at com.malinskiy.marathon.Marathon.access$onFinish(Marathon.kt:33)
	at com.malinskiy.marathon.Marathon$runAsync$hook$1.invokeSuspend(Marathon.kt:103)
	at com.malinskiy.marathon.Marathon$runAsync$hook$1.invoke(Marathon.kt)
	at com.malinskiy.marathon.Marathon$runAsync$hook$1.invoke(Marathon.kt)
	at com.malinskiy.marathon.Marathon$installShutdownHook$shutdownHook$1$1.invokeSuspend(Marathon.kt:129)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:279)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.malinskiy.marathon.Marathon$installShutdownHook$shutdownHook$1.invoke(Marathon.kt:128)
	at com.malinskiy.marathon.Marathon$installShutdownHook$shutdownHook$1.invoke(Marathon.kt:127)
	at com.malinskiy.marathon.ShutdownHook.run(ShutdownHook.kt:13)
```

To help investigate issues relating to failed exit code due to not all tests being executed the test run will now print the following in case of such problem:

```
E 00:58:07.859 [Thread-7] <c.m.m.e.p.tracker.PoolProgressTracker> Expected to run 49 tests but received results for only 3
```