### PR TITLE
[iOS]Added Support for Cucumberish Tags / Function Annotations

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
@@ -83,7 +83,8 @@ sealed class VendorConfiguration {
         @JsonProperty("compactOutput") val compactOutput: Boolean = false,
         @JsonProperty("keepAliveIntervalMillis") val keepAliveIntervalMillis: Long = 0L,
         @JsonProperty("devices") val devicesFile: File? = null,
-    ) : VendorConfiguration() {
+        @JsonProperty("xcTestRunnerTag") val xcTestRunnerTag: String? = null,
+        ) : VendorConfiguration() {
         /**
          * Exception should not happen since it will be first thrown in deserializer
          */

--- a/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/ConfigurationFactoryTest.kt
+++ b/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/ConfigurationFactoryTest.kt
@@ -274,6 +274,7 @@ class ConfigurationFactoryTest {
             keepAliveIntervalMillis = 300000L,
             devicesFile = file.parentFile.resolve("Testdevices").canonicalFile,
             sourceRoot = file.parentFile.resolve(".").canonicalFile,
+            xcTestRunnerTag = "demoTag"
         )
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -80,7 +80,7 @@ class Marathon(
         val shard = prepareTestShard(tests, analytics)
 
         log.info("Scheduling ${tests.size} tests")
-        log.debug(tests.joinToString(", ") { it.toTestName() })
+        log.info(tests.joinToString(", ") { it.toTestName() })
         val currentCoroutineContext = coroutineContext
         val scheduler = Scheduler(
             deviceProvider,

--- a/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/test/Test.kt
@@ -43,3 +43,13 @@ fun Test.toClassName(separator: Char = '.'): String {
 fun Test.toSimpleSafeTestName(): String = "$clazz.$method"
 
 fun Test.toSafeTestName() = toTestName(methodSeparator = '.')
+
+fun Test.getCucumberishTags(): List<String>{
+    var tags: List<String> = emptyList()
+
+    if (metaProperties.isNotEmpty()) {
+        val mappedValues = metaProperties.filter { it.name == "cucumberishTags" }.first().values
+        tags = mappedValues.get("tags") as? List<String> ?: emptyList()
+    }
+    return tags
+}

--- a/docs/_posts/2018-11-19-ios.md
+++ b/docs/_posts/2018-11-19-ios.md
@@ -96,3 +96,11 @@ this here
 ```yaml
 devicesFile: "/opt/Marathondevices"
 ```
+
+## Annotating Test Function Using Cucumberish @Tags
+You can annotate your test functions with cucumberish tags for ex: `@SmokeTest @RegressionTest` etc.
+If your Marathon file contains the parameter `xcTestRunnerTag`, then only the selected test functions will be executed by marathon.
+
+```yaml
+xcTestRunnerTag: "SmokeTest"
+```

--- a/sample/ios-app/Marathonfile
+++ b/sample/ios-app/Marathonfile
@@ -18,3 +18,4 @@ vendorConfiguration:
   knownHostsPath: ${HOME}/.ssh/known_hosts
   remoteUsername: ${USER}
   remotePrivateKey: ${HOME}/.ssh/marathon
+  xcTestRunnerTag: "SmokeTest"

--- a/sample/ios-app/sample-appUITests/StoryboardTests.swift
+++ b/sample/ios-app/sample-appUITests/StoryboardTests.swift
@@ -61,6 +61,19 @@ class StoryboardTests: XCTestCase {
         let label = app.staticTexts.firstMatch
         XCTAssertEqual(label.label, "Label")
     }
+
+    // @SmokeTest @RegressionTest
+    func testButtonBasedOnAnnotationOrTag() {
+        let button = app.buttons.firstMatch
+        XCTAssertTrue(button.waitForExistence())
+        XCTAssertTrue(button.isHittable)
+
+        button.tap()
+
+        let label = app.staticTexts.firstMatch
+        XCTAssertTrue(label.waitForExistence())
+    }
+
 }
 
 private let standardTimeout: TimeInterval = 30.0

--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSTestParser.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/IOSTestParser.kt
@@ -4,14 +4,18 @@ import com.malinskiy.marathon.config.vendor.VendorConfiguration
 import com.malinskiy.marathon.execution.TestParser
 import com.malinskiy.marathon.ios.xctestrun.Xctestrun
 import com.malinskiy.marathon.log.MarathonLogging
+import com.malinskiy.marathon.test.MetaProperty
 import com.malinskiy.marathon.test.Test
+import com.malinskiy.marathon.test.getCucumberishTags
 import java.io.File
 
 class IOSTestParser(private val vendorConfiguration: VendorConfiguration.IOSConfiguration) : TestParser {
     private val swiftTestClassRegex = """class ([^:\s]+)\s*:\s*XCTestCase""".toRegex()
     private val swiftTestMethodRegex = """^.*func\s+(test[^(\s]*)\s*\(.*$""".toRegex()
+    private val swiftTagRegex = """@([^:\s]+)\w*""".toRegex()
 
     private val logger = MarathonLogging.logger(IOSTestParser::class.java.simpleName)
+    private val CUCUMBERISH_TAGS = "cucumberishTags"
 
     /**
      *  Looks up test methods running a text search in swift files. Considers classes that explicitly inherit
@@ -35,7 +39,7 @@ class IOSTestParser(private val vendorConfiguration: VendorConfiguration.IOSConf
         val implementedTests = mutableListOf<Test>()
         for (file in swiftFilesWithTests) {
             var testClassName: String? = null
-            for (line in file.readLines()) {
+            for ((index, line) in file.readLines().withIndex()) {
                 val className = line.firstMatchOrNull(swiftTestClassRegex)
                 val methodName = line.firstMatchOrNull(swiftTestMethodRegex)
 
@@ -44,16 +48,45 @@ class IOSTestParser(private val vendorConfiguration: VendorConfiguration.IOSConf
                 }
 
                 if (testClassName != null && methodName != null) {
-                    implementedTests.add(Test(targetName, testClassName, methodName, emptyList()))
+                    // Find & Update Tags here
+                    val tagLine = file.readLines()[index - 1]
+                    val tags = swiftTagRegex.findAll(tagLine).map { it.groupValues[1] }.toList()
+
+                    if (tags.isEmpty()) {
+                        implementedTests.add(Test(targetName, testClassName, methodName, emptyList()))
+                    }
+                    else {
+                        val values = mapOf("tags" to tags)
+                        val metaProperty = MetaProperty(name = CUCUMBERISH_TAGS, values = values)
+                        implementedTests.add(Test(targetName, testClassName, methodName, arrayListOf(metaProperty)))
+                    }
                 }
             }
         }
 
-        val filteredTests = implementedTests.filter { !xctestrun.isSkipped(it) }
+        var filteredTests = implementedTests.filter { !xctestrun.isSkipped(it) }
+
+        filteredTests = filterByXCTestRunnerTag(filteredTests)
 
         logger.trace { filteredTests.map { "${it.clazz}.${it.method}" }.joinToString() }
         logger.info { "Found ${filteredTests.size} tests in ${swiftFilesWithTests.count()} files" }
 
+        return filteredTests
+    }
+
+    private fun filterByXCTestRunnerTag(tests: List<Test>): List<Test> {
+        if (vendorConfiguration.xcTestRunnerTag.isNullOrEmpty()) {
+            return tests
+        }
+
+        var filteredTests = tests
+        val testRunnerTag = vendorConfiguration.xcTestRunnerTag ?: ""
+
+        if (testRunnerTag.isNotEmpty()) {
+            filteredTests = filteredTests.filter {
+                it.getCucumberishTags().contains(testRunnerTag)
+            }
+        }
         return filteredTests
     }
 }


### PR DESCRIPTION
### Background
For Android, marathon already supports [Cucumber](https://cucumber.io/docs/cucumber/api/?lang=java) framework for BDD (Behaviour Driven Development) oriented UI Tests but the same is not present for iOS (which uses a similar [Cucumberish](https://github.com/Ahmed-Ali/Cucumberish)). 

### Problem
In order to leverage marathon to support cucumberish (for iOS) we may require a lot of effort.

### Solution
In Cucumber/Cucumberish, we annotate the scenarios/features with tags like `@SmokeTest @Regression`, etc.

Now considering if your project supports Cucumberish or not , there are two approaches:

1. If your iOS project is NOT using Cucumberish framework for writing tests, you can simply annotate your test functions and same will work with marathon.
2. However, if you are using Cucumberish, and trying to move out of it for a more robust solution, you can use [XCTest-Gherkin framework](https://github.com/net-a-porter-mobile/XCTest-Gherkin) to convert your Cucumberish Tests to native UI Tests and then tag as described below.

### How Test Functions Look Like
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/1243887/198903791-b88f9487-f593-4298-8a38-76b44580bd5b.png">


### Please Note
Test Functions can have multiple annotations but marathon will run only those tests which match the `xcTestRunnerTag` i.e. _only one tag at a time_

### Next Steps
We will add functionality to support multiple tags as well in the future :) 

