### PR TITLE
Update Apache Commons Text to 1.10.0

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -26,7 +26,7 @@ object Versions {
     val espressoRunner = "1.0.1"
     val junit = "4.13.2"
     val gson = "2.9.1"
-    val apacheCommonsText = "1.9"
+    val apacheCommonsText = "1.10.0"
     val apacheCommonsIO = "2.11.0"
     val apacheCommonsCodec = "1.15"
     val influxDbClient = "2.23"


### PR DESCRIPTION
Apache Commons Text library update to prevent issue
https://securitylab.github.com/advisories/GHSL-2022-018_Apache_Commons_Text/
