### PR TITLE
feat(core): create a bill of used device time at the end of the run

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/MappingTracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/MappingTracker.kt
@@ -2,6 +2,7 @@ package com.malinskiy.marathon.analytics
 
 import com.malinskiy.marathon.analytics.internal.pub.Tracker
 import com.malinskiy.marathon.analytics.internal.sub.DeviceConnectedEvent
+import com.malinskiy.marathon.analytics.internal.sub.DeviceDisconnectedEvent
 import com.malinskiy.marathon.analytics.internal.sub.DevicePreparingEvent
 import com.malinskiy.marathon.analytics.internal.sub.DeviceProviderPreparingEvent
 import com.malinskiy.marathon.analytics.internal.sub.TestEvent
@@ -14,6 +15,10 @@ import java.time.Instant
 class MappingTracker(private val trackerInternal: TrackerInternal) : Tracker {
     override fun deviceConnected(poolId: DevicePoolId, device: DeviceInfo) {
         trackerInternal.track(DeviceConnectedEvent(Instant.now(), poolId, device))
+    }
+
+    override fun deviceDisconnected(poolId: DevicePoolId, device: DeviceInfo) {
+        trackerInternal.track(DeviceDisconnectedEvent(Instant.now(), poolId, device))
     }
 
     override fun deviceProviderInit(serialNumber: String, startTime: Instant, finishTime: Instant) {

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/TrackerFactory.kt
@@ -18,6 +18,7 @@ import com.malinskiy.marathon.config.Configuration
 import com.malinskiy.marathon.io.FileManager
 import com.malinskiy.marathon.log.MarathonLogging
 import com.malinskiy.marathon.report.allure.AllureReporter
+import com.malinskiy.marathon.report.bill.BillingReporter
 import com.malinskiy.marathon.report.device.DeviceInfoJsonReporter
 import com.malinskiy.marathon.report.html.HtmlSummaryReporter
 import com.malinskiy.marathon.report.junit.JUnitReporter
@@ -88,6 +89,7 @@ internal class TrackerFactory(
         return ExecutionReportGenerator(
             listOf(
                 DeviceInfoJsonReporter(fileManager, gson),
+                BillingReporter(fileManager, gson),
                 JUnitReporter(configuration.outputDir),
                 TimelineReporter(TimelineSummaryProvider(), gson, configuration.outputDir),
                 RawJsonReporter(fileManager, gson),

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/pub/Track.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/pub/Track.kt
@@ -27,6 +27,10 @@ class Track : Tracker {
         delegates.forEach { it.deviceConnected(poolId, device) }
     }
 
+    override fun deviceDisconnected(poolId: DevicePoolId, device: DeviceInfo) {
+        delegates.forEach { it.deviceDisconnected(poolId, device) }
+    }
+
     override fun test(poolId: DevicePoolId, device: DeviceInfo, testResult: TestResult, final: Boolean) {
         delegates.forEach { it.test(poolId, device, testResult, final) }
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/pub/Tracker.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/pub/Tracker.kt
@@ -10,6 +10,7 @@ import java.time.Instant
  */
 interface Tracker {
     fun deviceConnected(poolId: DevicePoolId, device: DeviceInfo)
+    fun deviceDisconnected(poolId: DevicePoolId, device: DeviceInfo)
     fun deviceProviderInit(serialNumber: String, startTime: Instant, finishTime: Instant)
     fun devicePreparing(serialNumber: String, startTime: Instant, finishTime: Instant)
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReport.kt
@@ -12,6 +12,7 @@ import java.time.Instant
  */
 data class ExecutionReport(
     val deviceConnectedEvents: List<DeviceConnectedEvent>,
+    val deviceDisconnectedEvents: List<DeviceDisconnectedEvent>,
     val devicePreparingEvents: List<DevicePreparingEvent>,
     val deviceProviderPreparingEvent: List<DeviceProviderPreparingEvent>,
     val testEvents: List<TestEvent>
@@ -123,4 +124,10 @@ data class TestEvent(
     val device: DeviceInfo,
     val testResult: TestResult,
     val final: Boolean
+) : Event()
+
+data class DeviceDisconnectedEvent(
+    val instant: Instant,
+    val poolId: DevicePoolId,
+    val device: DeviceInfo
 ) : Event()

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReportGenerator.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/ExecutionReportGenerator.kt
@@ -6,12 +6,14 @@ import java.util.*
 class ExecutionReportGenerator(private val reporters: List<Reporter>) : TrackerInternal {
     private val devicePreparingEvents: MutableList<DevicePreparingEvent> = Collections.synchronizedList(LinkedList())
     private val deviceConnectedEvents: MutableList<DeviceConnectedEvent> = Collections.synchronizedList(LinkedList())
+    private val deviceDisconnectedEvents: MutableList<DeviceDisconnectedEvent> = Collections.synchronizedList(LinkedList())
     private val deviceProviderPreparingEvents: MutableList<DeviceProviderPreparingEvent> = Collections.synchronizedList(LinkedList())
     private val testEvents: MutableList<TestEvent> = Collections.synchronizedList(mutableListOf())
 
     override fun track(event: Event) {
         when (event) {
             is DeviceConnectedEvent -> deviceConnectedEvents.add(event)
+            is DeviceDisconnectedEvent -> deviceDisconnectedEvents.add(event)
             is DevicePreparingEvent -> devicePreparingEvents.add(event)
             is DeviceProviderPreparingEvent -> deviceProviderPreparingEvents.add(event)
             is TestEvent -> testEvents.add(event)
@@ -21,6 +23,7 @@ class ExecutionReportGenerator(private val reporters: List<Reporter>) : TrackerI
     override fun close() {
         val report = ExecutionReport(
             deviceConnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents.sortedBy { it.instant },
             devicePreparingEvents.sortedBy { it.start },
             deviceProviderPreparingEvents.sortedBy { it.start },
             testEvents.sortedBy { it.instant })

--- a/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/TrackerInternalAdapter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/analytics/internal/sub/TrackerInternalAdapter.kt
@@ -4,6 +4,7 @@ abstract class TrackerInternalAdapter : TrackerInternal {
     final override fun track(event: Event) {
         when (event) {
             is DeviceConnectedEvent -> trackDeviceConnected(event)
+            is DeviceDisconnectedEvent -> trackDeviceDisconnected(event)
             is DevicePreparingEvent -> trackDevicePreparing(event)
             is DeviceProviderPreparingEvent -> trackDeviceProviderPreparing(event)
             is TestEvent -> trackTest(event)
@@ -19,4 +20,6 @@ abstract class TrackerInternalAdapter : TrackerInternal {
     protected open fun trackDevicePreparing(event: DevicePreparingEvent) = Unit
 
     protected open fun trackDeviceConnected(event: DeviceConnectedEvent) = Unit
+
+    protected open fun trackDeviceDisconnected(event: Event) = Unit
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/io/FileType.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/io/FileType.kt
@@ -10,4 +10,5 @@ enum class FileType(val dir: String, val suffix: String) {
     SCREENSHOT("screenshot", "gif"),
     SCREENSHOT_PNG("screenshot", "png"),
     XCTESTRUN("xctestrun", "xctestrun"),
+    BILL("bill", "json"),
 }

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/bill/BillingReporter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/bill/BillingReporter.kt
@@ -1,0 +1,76 @@
+package com.malinskiy.marathon.report.bill
+
+import com.google.gson.Gson
+import com.malinskiy.marathon.analytics.internal.sub.ExecutionReport
+import com.malinskiy.marathon.device.DeviceInfo
+import com.malinskiy.marathon.device.DevicePoolId
+import com.malinskiy.marathon.io.FileManager
+import com.malinskiy.marathon.io.FileType
+import com.malinskiy.marathon.log.MarathonLogging
+import com.malinskiy.marathon.report.Reporter
+import java.time.Duration
+import java.time.Instant
+
+internal class BillingReporter(
+    private val fileManager: FileManager,
+    private val gson: Gson,
+) : Reporter {
+    private val defaultStart = Instant.now()
+    private val logger = MarathonLogging.logger {}
+    override fun generate(executionReport: ExecutionReport) {
+        val starts = mutableMapOf<String, Instant>()
+        val devices = executionReport.deviceConnectedEvents.associateBy { it.device.serialNumber }.mapValues { it.value.device }
+        val pools = executionReport.deviceConnectedEvents.associateBy { it.device.serialNumber }.mapValues { it.value.poolId }
+
+        executionReport.devicePreparingEvents.forEach {
+            if (starts.contains(it.serialNumber)) {
+                //Only replace if event finish is before current one
+                if (starts[it.serialNumber]?.isAfter(it.finish) == true) {
+                    starts[it.serialNumber] = it.finish
+                }
+            } else {
+                starts[it.serialNumber] = it.finish
+            }
+        }
+
+        val ends = mutableMapOf<String, Instant>();
+        executionReport.deviceDisconnectedEvents.forEach {
+            if (ends.contains(it.device.serialNumber)) {
+                //Only replace if event instant is after current one
+                if (ends[it.device.serialNumber]?.isBefore(it.instant) == true) {
+                    ends[it.device.serialNumber] = it.instant
+                }
+            } else {
+                ends[it.device.serialNumber] = it.instant
+            }
+        }
+
+        val defaultEnd = Instant.now()
+        val serials = starts.keys + ends.keys
+        val bills: List<DeviceBill> = serials.mapNotNull {
+            val start = starts[it] ?: defaultStart
+            val end = ends[it] ?: defaultEnd
+            val info = devices[it]
+            val pool = pools[it]
+            if (info != null && pool != null) {
+                DeviceBill(info, pool, start.toEpochMilli(), end.toEpochMilli(), Duration.between(start, end).toMillis())
+            } else {
+                logger.warn { "Failure to process device bill: missing timeline event" }
+                null
+            }
+        }
+
+        bills.forEach {
+            val json = gson.toJson(it)
+            fileManager.createFile(FileType.BILL, it.pool, it.device).writeText(json)
+        }
+    }
+}
+
+data class DeviceBill(
+    val device: DeviceInfo,
+    val pool: DevicePoolId,
+    val start: Long,
+    val end: Long,
+    val duration: Long,
+)

--- a/core/src/main/kotlin/com/malinskiy/marathon/report/timeline/TimelineSummaryProvider.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/report/timeline/TimelineSummaryProvider.kt
@@ -87,6 +87,7 @@ class TimelineSummaryProvider {
         val ignoredTests = executionReport.testEvents.count { it.testResult.isIgnored }
 
         val deviceConnectedEvents = executionReport.deviceConnectedEvents.groupBy { it.device.serialNumber }
+        val deviceDisconnectedEvents = executionReport.deviceDisconnectedEvents.groupBy { it.device.serialNumber }
         val devicePreparingEvent = executionReport.devicePreparingEvents.groupBy { it.serialNumber }
         val deviceProviderPreparingEvents = executionReport.deviceProviderPreparingEvent.groupBy { it.serialNumber }
         val testEvents = executionReport.testEvents.groupBy { it.device.serialNumber }
@@ -96,6 +97,7 @@ class TimelineSummaryProvider {
         val reports = keys.map { key ->
             key to ExecutionReport(
                 deviceConnectedEvents = deviceConnectedEvents[key] ?: emptyList(),
+                deviceDisconnectedEvents = deviceDisconnectedEvents[key] ?: emptyList(),
                 devicePreparingEvents = devicePreparingEvent[key] ?: emptyList(),
                 deviceProviderPreparingEvent = deviceProviderPreparingEvents[key] ?: emptyList(),
                 testEvents = testEvents[key] ?: emptyList()

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
@@ -41,11 +41,12 @@ class ExecutionReportTest {
             healthy = true
         )
         ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.INCOMPLETE),
                 createTestEvent(device, "test2", TestStatus.PASSED),
@@ -65,11 +66,12 @@ class ExecutionReportTest {
             healthy = true
         )
         ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test2", TestStatus.FAILURE, false),
                 createTestEvent(device, "test2", TestStatus.FAILURE, false),

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/ExecutionReportTest.kt
@@ -44,7 +44,7 @@ class ExecutionReportTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
@@ -69,7 +69,7 @@ class ExecutionReportTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
@@ -35,7 +35,7 @@ class JUnitReporterTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
@@ -61,7 +61,7 @@ class JUnitReporterTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
@@ -93,7 +93,7 @@ class JUnitReporterTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
@@ -126,7 +126,7 @@ class JUnitReporterTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
@@ -157,7 +157,7 @@ class JUnitReporterTest {
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
-            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            deviceDisconnectedEvents = emptyList(),
             devicePreparingEvents = emptyList(),
             deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(

--- a/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/report/JUnitReporterTest.kt
@@ -32,11 +32,12 @@ class JUnitReporterTest {
     fun `only Passed Tests and without retries should generate correct report`() {
         val device = getDevice()
         val report = ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.PASSED),
                 createTestEvent(device, "test2", TestStatus.PASSED),
@@ -57,11 +58,12 @@ class JUnitReporterTest {
     fun `only Failed Tests and without retries should generate correct report`() {
         val device = getDevice()
         val report = ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.FAILURE),
                 createTestEvent(device, "test2", TestStatus.INCOMPLETE),
@@ -88,11 +90,12 @@ class JUnitReporterTest {
             "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
             "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
         val report = ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace),
                 createTestEvent(device, "test2", TestStatus.IGNORED),
@@ -120,11 +123,12 @@ class JUnitReporterTest {
             "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
             "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
         val report = ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace, false),
                 createTestEvent(device, "test1", TestStatus.PASSED, final = true)
@@ -150,11 +154,12 @@ class JUnitReporterTest {
             "  at com.example.stacktrace.StackTraceExample.methodA(StackTraceExample.java:9)\n" +
             "  at com.example.stacktrace.StackTraceExample.main(StackTraceExample.java:5)"
         val report = ExecutionReport(
-            deviceProviderPreparingEvent = emptyList(),
-            devicePreparingEvents = emptyList(),
             deviceConnectedEvents = listOf(
                 DeviceConnectedEvent(Instant.now(), DevicePoolId("myPool"), device)
             ),
+            deviceDisconnectedEvents = deviceDisconnectedEvents.sortedBy { it.instant },
+            devicePreparingEvents = emptyList(),
+            deviceProviderPreparingEvent = emptyList(),
             testEvents = listOf(
                 createTestEvent(device, "test1", TestStatus.PASSED, final = false),
                 createTestEvent(device, "test1", TestStatus.FAILURE, stackTrace)


### PR DESCRIPTION
Sample json:
```json
{
  "device": {
    "operatingSystem": {
      "version": "30"
    },
    "serialNumber": "127.0.0.1:5037:emulator-5554",
    "model": "Android SDK built for x86_64",
    "manufacturer": "unknown",
    "networkState": "CONNECTED",
    "deviceFeatures": [
      "VIDEO",
      "SCREENSHOT"
    ],
    "healthy": true,
    "safeSerialNumber$delegate": {
      "_value": "127.0.0.1-5037-emulator-5554"
    }
  },
  "pool": {
    "name": "omni"
  },
  "start": 1674982865655,
  "end": 1674983183507,
  "duration": 317851
}
```
