### PR TITLE
fix(vendor): file in test serialization

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/json/FileSerializer.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/json/FileSerializer.kt
@@ -7,7 +7,7 @@ import com.google.gson.JsonSerializer
 import java.io.File
 import java.lang.reflect.Type
 
-internal class FileSerializer : JsonSerializer<File> {
+class FileSerializer : JsonSerializer<File> {
     override fun serialize(src: File, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
         return JsonPrimitive(src.absolutePath)
     }

--- a/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/MarathonFactory.kt
+++ b/vendor/vendor-test/src/main/kotlin/com/malinskiy/marathon/test/factory/MarathonFactory.kt
@@ -1,6 +1,7 @@
 package com.malinskiy.marathon.test.factory
 
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import com.malinskiy.marathon.Marathon
 import com.malinskiy.marathon.config.Configuration
 import com.malinskiy.marathon.device.DeviceProvider
@@ -10,6 +11,7 @@ import com.malinskiy.marathon.execution.bundle.TestBundleIdentifier
 import com.malinskiy.marathon.execution.command.parse.MarathonTestParseCommand
 import com.malinskiy.marathon.execution.progress.ProgressReporter
 import com.malinskiy.marathon.io.FileManager
+import com.malinskiy.marathon.json.FileSerializer
 import com.malinskiy.marathon.log.MarathonLogConfigurator
 import com.malinskiy.marathon.test.Mocks
 import com.malinskiy.marathon.test.StubDeviceProvider
@@ -18,6 +20,7 @@ import com.malinskiy.marathon.time.Timer
 import com.nhaarman.mockitokotlin2.mock
 import org.koin.core.context.startKoin
 import org.koin.dsl.module
+import java.io.File
 import java.time.Clock
 
 class MarathonFactory {
@@ -39,7 +42,10 @@ class MarathonFactory {
                 val configuration = get<Configuration>()
                 FileManager(configuration.outputConfiguration.maxPath, configuration.outputDir)
             }
-            single { Gson() }
+            single { GsonBuilder()
+                .registerTypeAdapter(File::class.java, FileSerializer())
+                .create()
+            }
             single<Clock> { Clock.systemDefaultZone() }
             single { timer ?: SystemTimer(get()) }
             single {


### PR DESCRIPTION
```
Failed making field 'java.io.File#path' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
com.google.gson.JsonIOException: Failed making field 'java.io.File#path' accessible; either increase its visibility or write a custom TypeAdapter for its declaring type.
	at app//com.google.gson.internal.reflect.ReflectionHelper.makeAccessible(ReflectionHelper.java:38)
	at app//com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:286)
	at app//com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130)
	at app//com.google.gson.Gson.getAdapter(Gson.java:556)
	at app//com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField(ReflectiveTypeAdapterFactory.java:160)
	at app//com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:294)
	at app//com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:130)
	at app//com.google.gson.Gson.getAdapter(Gson.java:556)
```

Here:

```
 file.writeText(**gson.toJson(testEvent.testResult)**)
```

Reason: 

No `File` serialization provided in test