### PR TITLE
fix(ios): propagate test status to skip successful tests

### DIFF
--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/executor/listener/video/ScreenRecordingListener.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/executor/listener/video/ScreenRecordingListener.kt
@@ -95,7 +95,7 @@ class ScreenRecordingListener(
             stop()
         }
         lastRemoteFile = null
-        pullVideo(test, false)
+        pullVideo(test, success)
     }
 
     private suspend fun pullVideo(test: Test, success: Boolean) {


### PR DESCRIPTION
ON_FAILURE screen recording policy should propagate test status to skip successful tests