### PR TITLE
feat(android): support boot timeout

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/android/TimeoutConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/android/TimeoutConfiguration.kt
@@ -14,4 +14,5 @@ data class TimeoutConfiguration(
     var screencapturer: Duration = Duration.ofMillis(300),
     var socketIdleTimeout: Duration = Duration.ofSeconds(30),
     var portForward: Duration = shell,
+    var boot: Duration = Duration.ofSeconds(30),
 )

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -112,12 +112,12 @@ class Marathon(
             parsedAllTests = when (testParser) {
                 is LocalTestParser -> testParser.extract()
                 is RemoteTestParser<*> -> {
-                    withRetry(3, 0) {
-                        withTimeoutOrNull(configuration.deviceInitializationTimeoutMillis) {
+                    withTimeoutOrNull(configuration.deviceInitializationTimeoutMillis) {
+                        withRetry(3, 0) {
                             val borrowedDevice = deviceProvider.borrow()
                             testParser.extract(borrowedDevice)
-                        } ?: throw NoDevicesException("Timed out waiting for a temporary device for remote test parsing")
-                    }
+                        }
+                    } ?: throw NoDevicesException("Timed out waiting for a temporary device for remote test parsing")
                 }
 
                 else -> {

--- a/docs/docs/android/configure.md
+++ b/docs/docs/android/configure.md
@@ -607,6 +607,7 @@ vendorConfiguration:
     install: "P1DT12H30M5S"
     screenrecorder: "PT1H"
     screencapturer: "PT1S"
+    boot: "PT30S"
 ```
 
 </TabItem>

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamDeviceProvider.kt
@@ -179,10 +179,10 @@ class AdamDeviceProvider(
     }
 
     override suspend fun borrow(): AdamAndroidDevice {
-        var availableDevices = devices.filter { it.value.setupJob.isCompleted }
+        var availableDevices = devices.filter { it.value.setupJob.isCompleted && !it.value.setupJob.isCancelled }
         while(availableDevices.isEmpty()) {
             delay(200)
-            availableDevices = devices.filter { it.value.setupJob.isCompleted }
+            availableDevices = devices.filter { it.value.setupJob.isCompleted && !it.value.setupJob.isCancelled }
         }
         return availableDevices.values.random().device
     }


### PR DESCRIPTION
+ fix android device borrowing when devices are not ready
+ deviceInitializationTimeoutMillis should work all retries for remote parsing, not individual

Closes #835