### PR TITLE
fix(ios): removing unsupported arch added

### DIFF
--- a/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/xctestrun/TestRootFactory.kt
+++ b/vendor/vendor-ios/src/main/kotlin/com/malinskiy/marathon/ios/xctestrun/TestRootFactory.kt
@@ -271,6 +271,9 @@ class TestRootFactory(private val device: AppleSimulatorDevice, private val vend
             if (supportedArchs.contains(Arch.x86_64) && device.arch != Arch.arm64) {
                 // Launch as plain x86_64 if test binary has been built for simulator and is targeting x86_64
                 device.binaryEnvironment.lipo.removeArch(testRunnerBinary, Arch.arm64)
+            } else if (supportedArchs.contains(Arch.x86_64) && !supportedArchs.contains(Arch.arm64)) {
+                // Launch as plain x86_64 if test binary supports only x86_64
+                device.binaryEnvironment.lipo.removeArch(testRunnerBinary, Arch.arm64)
             }
         }
     }


### PR DESCRIPTION
Remove simulator arm64 arch if testBinary doesn't support it