### PR TITLE
Enable video record through screenrecord binary on Genymotion devices

### DIFF
--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -174,7 +174,7 @@ abstract class BaseAndroidDevice(
     }
 
     private suspend fun detectFeatures(): List<DeviceFeature> {
-        val hasScreenRecord = when {
+        val screenRecordSupport = when {
             !version.isGreaterOrEqualThan(19) -> false
             else -> hasBinary("/system/bin/screenrecord")
         }
@@ -182,7 +182,7 @@ abstract class BaseAndroidDevice(
 
         val features = mutableListOf<DeviceFeature>()
 
-        if (hasScreenRecord) features.add(DeviceFeature.VIDEO)
+        if (screenRecordSupport) features.add(DeviceFeature.VIDEO)
         if (screenshotSupport) features.add(DeviceFeature.SCREENSHOT)
         return features
     }

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -178,12 +178,11 @@ abstract class BaseAndroidDevice(
             !version.isGreaterOrEqualThan(19) -> false
             else -> hasBinary("/system/bin/screenrecord")
         }
-        val videoSupport = hasScreenRecord && manufacturer != "Genymotion"
         val screenshotSupport = version.isGreaterOrEqualThan(AndroidVersion.VersionCodes.JELLY_BEAN)
 
         val features = mutableListOf<DeviceFeature>()
 
-        if (videoSupport) features.add(DeviceFeature.VIDEO)
+        if (hasScreenRecord) features.add(DeviceFeature.VIDEO)
         if (screenshotSupport) features.add(DeviceFeature.SCREENSHOT)
         return features
     }


### PR DESCRIPTION
remove the check that returns false if the device manufacturer is Genymotion