### PR TITLE
fix(android): fix ConcurrentModificationException in AdamAndroidDevice

### DIFF
--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamAndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AdamAndroidDevice.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.withContext
 import java.awt.image.BufferedImage
 import java.io.File
 import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.CoroutineContext
 import com.malinskiy.marathon.android.model.ShellCommandResult as MarathonShellCommandResult
 
@@ -345,18 +346,14 @@ class AdamAndroidDevice(
         }
     }
 
-    private val logcatListeners = mutableListOf<LineListener>()
+    private val logcatListeners = CopyOnWriteArrayList<LineListener>()
 
     override fun addLineListener(listener: LineListener) {
-        synchronized(logcatListeners) {
-            logcatListeners.add(listener)
-        }
+        logcatListeners.add(listener)
     }
 
     override fun removeLineListener(listener: LineListener) {
-        synchronized(logcatListeners) {
-            logcatListeners.remove(listener)
-        }
+        logcatListeners.remove(listener)
     }
 
     override suspend fun safeStartScreenRecorder(


### PR DESCRIPTION
Listeners for log messages are mostly loaded by traversal and modifications are performed before and after each test batch, so copy-on-write implementation makes more sense. synchronized block is implemented by the class itself making synchronization in the adam device redundant

Closes #882