### PR TITLE
fix(android): DexTestParser should support empty package

### DIFF
--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DexTestParser.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/DexTestParser.kt
@@ -32,7 +32,8 @@ class DexTestParser(
                 val packageAndClassName = split[0]
 
                 val lastDotIndex = packageAndClassName.indexOfLast { c -> c == '.' }
-                val packageName = packageAndClassName.substring(0 until lastDotIndex)
+                val packageName = if (lastDotIndex == -1) "" else packageAndClassName.substring(0 until lastDotIndex)
+
                 val className = packageAndClassName.substring(lastDotIndex + 1 until packageAndClassName.length)
 
                 val test = Test(packageName, className, methodName, annotations)


### PR DESCRIPTION
Fixes:
```
java.lang.StringIndexOutOfBoundsException: begin 0, end -1, length 20
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4606)
	at java.base/java.lang.String.substring(String.java:2709)
	at kotlin.text.StringsKt__StringsKt.substring(Strings.kt:393)
	at com.malinskiy.marathon.android.DexTestParser.extract(DexTestParser.kt:35)
	at com.malinskiy.marathon.Marathon.runAsync(Marathon.kt:113)
	at com.malinskiy.marathon.Marathon$runAsync$1.invokeSuspend(Marathon.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:32)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(CoroutineContext.kt:270)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:280)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.malinskiy.marathon.Marathon.run(Marathon.kt:69)
	at com.malinskiy.marathon.cli.ApplicationViewKt.execute(ApplicationView.kt:85)
	at com.malinskiy.marathon.cli.ApplicationViewKt.access$execute(ApplicationView.kt:1)
	at com.malinskiy.marathon.cli.ApplicationViewKt$main$1.invoke(ApplicationView.kt:33)
	at com.malinskiy.marathon.cli.ApplicationViewKt$main$1.invoke(ApplicationView.kt:33)
	at com.malinskiy.marathon.cli.args.MarathonCli.run(CliCommands.kt:42)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:279)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:41)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:457)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:454)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:474)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:481)
	at com.malinskiy.marathon.cli.ApplicationViewKt.main(ApplicationView.kt:35)
```