### PR TITLE
feat(apple): implement importMedia for simulators

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/serialization/ConfigurationFactory.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/serialization/ConfigurationFactory.kt
@@ -84,6 +84,9 @@ class ConfigurationFactory(
                             it.testType
                         ).apply { validate() }
                     }
+
+                    val resolvedMediaFiles = iosConfiguration.mediaFiles?.map { ddd -> marathonfileDir.resolve(ddd) }
+
                     val optionalDevices = configuration.vendorConfiguration.devicesFile?.resolveAgainst(marathonfileDir)
                         ?: marathonfileDir.resolve("Marathondevices")
 
@@ -104,6 +107,7 @@ class ConfigurationFactory(
 
                     configuration.vendorConfiguration.copy(
                         bundle = resolvedBundle,
+                        mediaFiles = resolvedMediaFiles,
                         devicesFile = optionalDevices,
                         ssh = optionalSshConfiguration,
                     )

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
@@ -163,7 +163,7 @@ sealed class VendorConfiguration {
         @JsonProperty("xctestrunEnv") val xctestrunEnv: XctestrunEnvConfiguration = XctestrunEnvConfiguration(),
         @JsonProperty("lifecycle") val lifecycleConfiguration: LifecycleConfiguration = LifecycleConfiguration(),
         @JsonProperty("permissions") val permissions: PermissionsConfiguration = PermissionsConfiguration(),
-        @JsonProperty("pushMediaFiles") val mediaFiles: List<File>? = null,
+        @JsonProperty("importMedia") val mediaFiles: List<File>? = null,
         @JsonProperty("timeoutConfiguration") val timeoutConfiguration: AppleTimeoutConfiguration = AppleTimeoutConfiguration(),
         @JsonProperty("threadingConfiguration") val threadingConfiguration: AppleThreadingConfiguration = AppleThreadingConfiguration(),
         @JsonProperty("hideRunnerOutput") val hideRunnerOutput: Boolean = false,

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/VendorConfiguration.kt
@@ -163,6 +163,7 @@ sealed class VendorConfiguration {
         @JsonProperty("xctestrunEnv") val xctestrunEnv: XctestrunEnvConfiguration = XctestrunEnvConfiguration(),
         @JsonProperty("lifecycle") val lifecycleConfiguration: LifecycleConfiguration = LifecycleConfiguration(),
         @JsonProperty("permissions") val permissions: PermissionsConfiguration = PermissionsConfiguration(),
+        @JsonProperty("pushMediaFiles") val mediaFiles: List<File>? = null,
         @JsonProperty("timeoutConfiguration") val timeoutConfiguration: AppleTimeoutConfiguration = AppleTimeoutConfiguration(),
         @JsonProperty("threadingConfiguration") val threadingConfiguration: AppleThreadingConfiguration = AppleThreadingConfiguration(),
         @JsonProperty("hideRunnerOutput") val hideRunnerOutput: Boolean = false,

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/TimeoutConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/TimeoutConfiguration.kt
@@ -23,7 +23,7 @@ data class TimeoutConfiguration(
     @JsonProperty("boot") var boot: Duration = shell,
     @JsonProperty("install") var install: Duration = shell,
     @JsonProperty("uninstall") var uninstall: Duration = shell,
-    @JsonProperty("pushMedia") var pushMedia: Duration = shell,
+    @JsonProperty("importMedia") var importMedia: Duration = shell,
     @JsonProperty("testDestination") var testDestination: Duration = Duration.ofSeconds(30),
 ) {
     

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/TimeoutConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/TimeoutConfiguration.kt
@@ -23,6 +23,7 @@ data class TimeoutConfiguration(
     @JsonProperty("boot") var boot: Duration = shell,
     @JsonProperty("install") var install: Duration = shell,
     @JsonProperty("uninstall") var uninstall: Duration = shell,
+    @JsonProperty("pushMedia") var pushMedia: Duration = shell,
     @JsonProperty("testDestination") var testDestination: Duration = Duration.ofSeconds(30),
 ) {
     

--- a/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/IosConfigurationFactoryTest.kt
+++ b/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/IosConfigurationFactoryTest.kt
@@ -19,7 +19,11 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.malinskiy.marathon.config.serialization.yaml.SerializeModule
+import com.malinskiy.marathon.config.vendor.apple.TimeoutConfiguration
 import com.malinskiy.marathon.config.vendor.apple.TestType
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldHaveSize
 
 class IosConfigurationFactoryTest {
     private val mockMarathonFileDir = File(ConfigurationFactoryTest::class.java.getResource("/fixture/config/ios").file)
@@ -98,5 +102,40 @@ class IosConfigurationFactoryTest {
 
         val iosConfiguration = configuration.vendorConfiguration as VendorConfiguration.IOSConfiguration
         iosConfiguration.bundle?.testType shouldBeEqualTo TestType.XCUITEST
+    }
+
+    @Test
+    fun `on configuration with push media files`() {
+        val file = File(ConfigurationFactoryTest::class.java.getResource("/fixture/config/ios/sample_4.yaml").file)
+        val configuration = parser.parse(file)
+
+        val iosConfiguration = configuration.vendorConfiguration as VendorConfiguration.IOSConfiguration
+        iosConfiguration.mediaFiles?.shouldHaveSize(2)
+        iosConfiguration.mediaFiles?.shouldContain(file.parentFile.resolve("media/empty.jpg").canonicalFile)
+        iosConfiguration.mediaFiles?.shouldContain(file.parentFile.resolve("media/empty.mp4").canonicalFile)
+    }
+
+    @Test
+    fun `on configuration with timeout configuration in iOS`() {
+        val file = File(ConfigurationFactoryTest::class.java.getResource("/fixture/config/ios/sample_5.yaml").file)
+        val configuration = parser.parse(file)
+
+        val timeoutConfiguration = (configuration.vendorConfiguration as VendorConfiguration.IOSConfiguration).timeoutConfiguration
+        timeoutConfiguration `should be equal to` TimeoutConfiguration(
+            shell = Duration.ofSeconds(30),
+            shellIdle = Duration.ofSeconds(31),
+            reachability = Duration.ofMinutes(1),
+            screenshot = Duration.ofMinutes(2),
+            video = Duration.ofHours(1),
+            erase = Duration.ofHours(2),
+            shutdown = Duration.ofDays(1),
+            delete = Duration.ofSeconds(3),
+            create = Duration.parse("P1DT12H30M5S"),
+            boot = Duration.ofSeconds(80),
+            install = Duration.ofHours(3),
+            uninstall = Duration.ofSeconds(62),
+            pushMedia = Duration.ofSeconds(6),
+            testDestination = Duration.ofSeconds(34),
+        )
     }
 }

--- a/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/IosConfigurationFactoryTest.kt
+++ b/configuration/src/test/kotlin/com/malinskiy/marathon/config/serialization/IosConfigurationFactoryTest.kt
@@ -105,7 +105,7 @@ class IosConfigurationFactoryTest {
     }
 
     @Test
-    fun `on configuration with push media files`() {
+    fun `on configuration with import media files`() {
         val file = File(ConfigurationFactoryTest::class.java.getResource("/fixture/config/ios/sample_4.yaml").file)
         val configuration = parser.parse(file)
 
@@ -134,7 +134,7 @@ class IosConfigurationFactoryTest {
             boot = Duration.ofSeconds(80),
             install = Duration.ofHours(3),
             uninstall = Duration.ofSeconds(62),
-            pushMedia = Duration.ofSeconds(6),
+            importMedia = Duration.ofSeconds(6),
             testDestination = Duration.ofSeconds(34),
         )
     }

--- a/configuration/src/test/resources/fixture/config/ios/sample_4.yaml
+++ b/configuration/src/test/resources/fixture/config/ios/sample_4.yaml
@@ -1,0 +1,16 @@
+name: "sample-app tests"
+outputDir: "./marathon"
+vendorConfiguration:
+  type: "iOS"
+  bundle:
+    derivedDataDir: "derivedDataDir"
+    testType: xcuitest
+  pushMediaFiles:
+    - "media/empty.jpg"
+    - "media/empty.mp4"
+  ssh:
+    authentication:
+      type: "publicKey"
+      username: "testuser"
+      key: "/home/testuser/.ssh/id_rsa"
+    debug: true

--- a/configuration/src/test/resources/fixture/config/ios/sample_4.yaml
+++ b/configuration/src/test/resources/fixture/config/ios/sample_4.yaml
@@ -5,7 +5,7 @@ vendorConfiguration:
   bundle:
     derivedDataDir: "derivedDataDir"
     testType: xcuitest
-  pushMediaFiles:
+  importMedia:
     - "media/empty.jpg"
     - "media/empty.mp4"
   ssh:

--- a/configuration/src/test/resources/fixture/config/ios/sample_5.yaml
+++ b/configuration/src/test/resources/fixture/config/ios/sample_5.yaml
@@ -1,0 +1,28 @@
+name: "sample-app tests"
+outputDir: "./marathon"
+vendorConfiguration:
+  type: "iOS"
+  bundle:
+    derivedDataDir: "derivedDataDir"
+  ssh:
+    authentication:
+      type: "publicKey"
+      username: "testuser"
+      key: "/home/testuser/.ssh/id_rsa"
+    debug: true
+  timeoutConfiguration:
+    shell: PT30S
+    shellIdle: PT31S
+    reachability: PT1M
+    screenshot: PT2M
+    video: PT1H
+    erase: PT2H
+    shutdown: P1D
+    delete: PT3S
+    create: P1DT12H30M5S
+    boot: PT80S
+    install: PT3H
+    uninstall: PT62S
+    pushMedia: PT6S
+    testDestination: PT34S
+

--- a/configuration/src/test/resources/fixture/config/ios/sample_5.yaml
+++ b/configuration/src/test/resources/fixture/config/ios/sample_5.yaml
@@ -23,6 +23,6 @@ vendorConfiguration:
     boot: PT80S
     install: PT3H
     uninstall: PT62S
-    pushMedia: PT6S
+    importMedia: PT6S
     testDestination: PT34S
 

--- a/docs/runner/apple/configure/ios.md
+++ b/docs/runner/apple/configure/ios.md
@@ -299,6 +299,21 @@ The `display` and `mask` fields have the same options as the video recorder.
 The `type` specifies the format of a single frame and is advised not to be changes.
 The `delay` field specifies the minimal delay between frames using [ISO 8601][3] notation.
 
+### Push media files to apple simulator before test run
+
+Sometimes you need to push some media files such as photos, live photos, videos, or contacts to the library of a device. Here is how you can configure it:
+
+:::info
+
+All files will be pushed using the `simctl addmedia` command, which is only available for apple simulators.
+
+:::
+```yaml
+pushMediaFiles:
+  - "media/photo.jpg"
+  - "media/video.mp4"
+```
+
 ### xctestrun Environment and TestingEnvironment variables
 
 You can specify additional Environment and TestingEnvironment variables for your test run:
@@ -479,6 +494,7 @@ timeoutConfiguration:
 | install         | Timeout for installing applications (does not apply for the app bundle or test bundle)             |
 | uninstall       | Timeout for uninstalling applications                                                              |
 | testDestination | Timeout for waiting for simulator specified to xcodebuild                                          |
+| pushMedia       | Timeout for pushing a media file to simulator                                                      |
 
 ### Threading
 

--- a/docs/runner/apple/configure/ios.md
+++ b/docs/runner/apple/configure/ios.md
@@ -307,11 +307,22 @@ Sometimes you need to push some media files such as photos, live photos, videos,
 
 All files will be pushed using the `simctl addmedia` command, which is only available for apple simulators.
 
+
+This import will only be done once per device provisioning, so in the simplest case once before a test run. So if the test manipulates these in any way - it's the test's responsibility to reset it to the state needed.
+
+:::
+
+:::warning
+
+The imported files will remain on the device throughout its entire life cycle.
+New test runs will produce new file imports. To avoid increasing the simulator storage growth or side effects from the previous test runs -  read how to erase it before/after test runs - [Test run lifecycle][4]
+
 :::
 ```yaml
-pushMediaFiles:
+importMedia:
   - "media/photo.jpg"
   - "media/video.mp4"
+  - "media/contact.vcf"
 ```
 
 ### xctestrun Environment and TestingEnvironment variables
@@ -477,6 +488,7 @@ timeoutConfiguration:
   install: PT30S
   uninstall: PT30S
   testDestination: PT30S
+  importMedia: PT30S
 ```
 
 | Name            | Description                                                                                        |
@@ -494,7 +506,7 @@ timeoutConfiguration:
 | install         | Timeout for installing applications (does not apply for the app bundle or test bundle)             |
 | uninstall       | Timeout for uninstalling applications                                                              |
 | testDestination | Timeout for waiting for simulator specified to xcodebuild                                          |
-| pushMedia       | Timeout for pushing a media file to simulator                                                      |
+| importMedia     | Timeout for importing a media file to simulator                                                    |
 
 ### Threading
 
@@ -641,4 +653,5 @@ deviceLog: true
 [1]: ../workers.md
 [2]: ../../configuration/dynamic-configuration.md
 [3]: https://en.wikipedia.org/wiki/ISO_8601
+[4]: #test-run-lifecycle
 [libxctest-parser-license]: https://github.com/MarathonLabs/marathon/blob/-/vendor/vendor-apple/base/src/main/resources/EULA.md

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/RemoteFileManager.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/RemoteFileManager.kt
@@ -16,6 +16,7 @@ class RemoteFileManager(private val device: AppleDevice) {
 
     fun remoteDirectory(): String = outputDir
     fun remoteSharedDirectory(): String = AppleDevice.SHARED_PATH + "/shared/"
+    fun remoteSharedMediaDirectory(): String = remoteSharedDirectory() + "mediaFiles/"
 
     suspend fun createRemoteDirectory(remoteDir: String = remoteDirectory()) {
         executeCommand(
@@ -25,6 +26,8 @@ class RemoteFileManager(private val device: AppleDevice) {
     }
 
     suspend fun createRemoteSharedDirectory() = createRemoteDirectory(remoteSharedDirectory())
+
+    suspend fun createRemoteSharedMediaDirectory() = createRemoteDirectory(remoteSharedMediaDirectory())
 
     suspend fun removeRemoteDirectory() {
         executeCommand(
@@ -47,6 +50,7 @@ class RemoteFileManager(private val device: AppleDevice) {
     fun remoteXctestParserFile(): String = remoteSharedFile(`libXctestParserFileName`())
     fun remoteApplication(): String = remoteSharedFile(appUnderTestFileName())
     fun remoteExtraApplication(name: String) = remoteSharedFile(name)
+    fun remoteMediaFile(file: String): String = remoteSharedMediaDirectory().resolve(file)
 
     /**
      * Omitting xcresult extension results in a symlink

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/Simctl.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/Simctl.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.ApplicationService
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.DeviceService
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.IoService
+import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.MediaService
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.PrivacyService
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.SimulatorService
 import com.malinskiy.marathon.apple.bin.xcrun.simctl.service.SpawnService
@@ -23,6 +24,7 @@ class Simctl(
     val simulator = SimulatorService(commandExecutor, timeoutConfiguration)
     val io = IoService(commandExecutor, timeoutConfiguration)
     val privacy = PrivacyService(commandExecutor, timeoutConfiguration)
+    val mediaService = MediaService(commandExecutor, timeoutConfiguration)
     val application = ApplicationService(commandExecutor, timeoutConfiguration)
     val spawn = SpawnService(commandExecutor, timeoutConfiguration)
 }

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/service/MediaService.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/service/MediaService.kt
@@ -1,0 +1,19 @@
+package com.malinskiy.marathon.apple.bin.xcrun.simctl.service
+
+import com.malinskiy.marathon.apple.bin.xcrun.simctl.SimctlService
+import com.malinskiy.marathon.apple.cmd.CommandExecutor
+import com.malinskiy.marathon.apple.cmd.CommandResult
+import com.malinskiy.marathon.config.vendor.apple.TimeoutConfiguration
+
+class MediaService(
+    commandExecutor: CommandExecutor,
+    private val timeoutConfiguration: TimeoutConfiguration,
+) : SimctlService(commandExecutor) {
+
+    suspend fun addMedia(udid: String, remotePath: String): CommandResult {
+        return criticalExec(
+            timeout = timeoutConfiguration.pushMedia,
+            "addmedia", udid, remotePath
+        )
+    }
+}

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/service/MediaService.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/bin/xcrun/simctl/service/MediaService.kt
@@ -12,7 +12,7 @@ class MediaService(
 
     suspend fun addMedia(udid: String, remotePath: String): CommandResult {
         return criticalExec(
-            timeout = timeoutConfiguration.pushMedia,
+            timeout = timeoutConfiguration.importMedia,
             "addmedia", udid, remotePath
         )
     }

--- a/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
+++ b/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
@@ -217,8 +217,8 @@ class AppleSimulatorDevice(
                             if (!boot()) {
                                 logger.warn("Exception booting simulator $udid")
                             }
-                            AppleSimulatorMediaPusher(vendorConfiguration)
-                                .addMedia(this@AppleSimulatorDevice)
+                            AppleSimulatorMediaImporter(vendorConfiguration)
+                                .importMedia(this@AppleSimulatorDevice)
                         })
                     }.awaitAll()
                 }
@@ -455,7 +455,7 @@ class AppleSimulatorDevice(
         return binaryEnvironment.xcrun.simctl.application.install(udid, remotePath).successful
     }
 
-    suspend fun addMedia(remotePath: String): Boolean {
+    suspend fun importMedia(remotePath: String): Boolean {
         return binaryEnvironment.xcrun.simctl.mediaService.addMedia(udid, remotePath).successful
     }
 

--- a/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
+++ b/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
@@ -217,6 +217,8 @@ class AppleSimulatorDevice(
                             if (!boot()) {
                                 logger.warn("Exception booting simulator $udid")
                             }
+                            AppleSimulatorMediaPusher(vendorConfiguration)
+                                .addMedia(this@AppleSimulatorDevice)
                         })
                     }.awaitAll()
                 }
@@ -450,6 +452,10 @@ class AppleSimulatorDevice(
 
     override suspend fun install(remotePath: String): Boolean {
         return binaryEnvironment.xcrun.simctl.application.install(udid, remotePath).successful
+    }
+
+    suspend fun addMedia(remotePath: String): Boolean {
+        return binaryEnvironment.xcrun.simctl.mediaService.addMedia(udid, remotePath).successful
     }
 
     override suspend fun startVideoRecording(remotePath: String): CommandResult? {

--- a/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorMediaImporter.kt
+++ b/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorMediaImporter.kt
@@ -6,12 +6,12 @@ import com.malinskiy.marathon.exceptions.DeviceSetupException
 import com.malinskiy.marathon.execution.withRetry
 import com.malinskiy.marathon.log.MarathonLogging
 
-class AppleSimulatorMediaPusher(override val vendorConfiguration: VendorConfiguration.IOSConfiguration) :
+class AppleSimulatorMediaImporter(override val vendorConfiguration: VendorConfiguration.IOSConfiguration) :
     AppleApplicationInstaller<AppleSimulatorDevice>(vendorConfiguration) {
 
     private val logger = MarathonLogging.logger {}
 
-    suspend fun addMedia(device: AppleSimulatorDevice) {
+    suspend fun importMedia(device: AppleSimulatorDevice) {
         if (vendorConfiguration.mediaFiles.isNullOrEmpty()) return
 
         device.remoteFileManager.createRemoteSharedMediaDirectory()
@@ -23,9 +23,9 @@ class AppleSimulatorMediaPusher(override val vendorConfiguration: VendorConfigur
                 throw DeviceSetupException("Error transferring $remoteMediaFile to ${device.serialNumber}")
             }
             withRetry(3, 1000L) {
-                logger.debug { "Adding media $mFile to ${device.serialNumber}" }
-                if (!device.addMedia(remoteMediaFile)) {
-                    throw DeviceSetupException("Error adding media $remoteMediaFile to ${device.serialNumber}")
+                logger.debug { "Importing media $mFile to ${device.serialNumber}" }
+                if (!device.importMedia(remoteMediaFile)) {
+                    throw DeviceSetupException("Error importing media $remoteMediaFile to ${device.serialNumber}")
                 }
             }
         }

--- a/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorMediaPusher.kt
+++ b/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorMediaPusher.kt
@@ -1,0 +1,33 @@
+package com.malinskiy.marathon.apple.ios
+
+import com.malinskiy.marathon.apple.AppleApplicationInstaller
+import com.malinskiy.marathon.config.vendor.VendorConfiguration
+import com.malinskiy.marathon.exceptions.DeviceSetupException
+import com.malinskiy.marathon.execution.withRetry
+import com.malinskiy.marathon.log.MarathonLogging
+
+class AppleSimulatorMediaPusher(override val vendorConfiguration: VendorConfiguration.IOSConfiguration) :
+    AppleApplicationInstaller<AppleSimulatorDevice>(vendorConfiguration) {
+
+    private val logger = MarathonLogging.logger {}
+
+    suspend fun addMedia(device: AppleSimulatorDevice) {
+        if (vendorConfiguration.mediaFiles.isNullOrEmpty()) return
+
+        device.remoteFileManager.createRemoteSharedMediaDirectory()
+
+        vendorConfiguration.mediaFiles?.forEach { mFile ->
+            val remoteMediaFile = device.remoteFileManager.remoteMediaFile(mFile.name)
+
+            if (!device.pushFile(mFile, remoteMediaFile)) {
+                throw DeviceSetupException("Error transferring $remoteMediaFile to ${device.serialNumber}")
+            }
+            withRetry(3, 1000L) {
+                logger.debug { "Adding media $mFile to ${device.serialNumber}" }
+                if (!device.addMedia(remoteMediaFile)) {
+                    throw DeviceSetupException("Error adding media $remoteMediaFile to ${device.serialNumber}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to push media files to the apple simulator before test run using `xcrun simctl addmedia`
A vendor configuration looks like:
```yaml
importMedia:
  - "media/photo.jpg"
  - "media/video.mp4"
  - "media/contact.vcf"
```

I'm open to rework it in any other configuration ways.

UPDATE: changed the snippet to reflect the final configuration format

