### PR TITLE
feat(core): comments support in value filtering files

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FilterValuesFileReader.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/FilterValuesFileReader.kt
@@ -1,0 +1,23 @@
+package com.malinskiy.marathon.execution.filter
+
+import com.malinskiy.marathon.log.MarathonLogging
+import java.io.File
+
+class FilterValuesFileReader {
+    private val log = MarathonLogging.logger("FilterValuesFileReader")
+
+    fun readValues(file: File?) = file?.let { valuesFile ->
+        if (valuesFile.exists()) {
+            valuesFile.readLines().filter { it.isNotBlank() && !it.isCommentLine() }.map { it.trimCommentFromLine() }
+        } else {
+            log.error { "Filtering configuration file ${valuesFile.absoluteFile} does not exist. Applying empty list." }
+            emptyList()
+        }
+    }
+
+    private fun String.trimCommentFromLine() = this.replace("\\s+#.*$".toRegex(), "").trim()
+
+    private fun String.isCommentLine(): Boolean {
+        return this.trim().startsWith("#")
+    }
+}

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/SingleValueTestFilter.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/filter/SingleValueTestFilter.kt
@@ -14,14 +14,7 @@ open class SingleValueTestFilter(
     private val log = MarathonLogging.logger("SingleValueTestFilter")
 
     private val fileValuesCache: List<String>? by lazy {
-        file?.let { valuesFile ->
-            if (valuesFile.exists()) {
-                valuesFile.readLines().filter { it.isNotBlank() }
-            } else {
-                log.error { "Filtering configuration file ${valuesFile.absoluteFile} does not exist. Applying empty list." }
-                emptyList()
-            }
-        }
+        FilterValuesFileReader().readValues(file)
     }
 
     private fun readValues(): List<String>? {

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/FilterValuesFileReaderTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/FilterValuesFileReaderTest.kt
@@ -1,0 +1,28 @@
+package com.malinskiy.marathon.execution.filter
+
+import org.amshove.kluent.shouldContainAll
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class FilterValuesFileReaderTest {
+
+    private val valueFile = File(FilterValuesFileReaderTest::class.java.getResource("/testfilters/valuelist_1").file)
+    private val valuesFileReader = FilterValuesFileReader()
+
+    @Test
+    fun shouldIgnoreComments() {
+        val expectedValueList = listOf(
+            "com.example.test1",
+            "com.example.test2",
+            "com.example",
+            "ClassName#test4",
+            "SimpleTestName",
+            "SimpleTestName2"
+        )
+        val values = valuesFileReader.readValues(valueFile)
+
+        values?.shouldHaveSize(expectedValueList.size)
+        values?.shouldContainAll(expectedValueList)
+    }
+}

--- a/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/SingleValueTestFilterTest.kt
+++ b/core/src/test/kotlin/com/malinskiy/marathon/execution/filter/SingleValueTestFilterTest.kt
@@ -8,6 +8,25 @@ import org.junit.jupiter.api.Test
 
 class SingleValueTestFilterTest {
     @Test
+    fun `should filter block list from value file`() {
+        val blockedTest = MarathonTest("pkg", "clazz", "method", emptyList())
+        val allowedTest = MarathonTest("pkg", "clazz2", "method", emptyList())
+        val inputTests = listOf(blockedTest, allowedTest)
+
+        val blocklistEmptyFileFilter = FullyQualifiedClassnameFilter(
+            TestFilterConfiguration.FullyQualifiedClassnameFilterConfiguration(
+                regex = null,
+                values = null,
+                file = File(SingleValueTestFilterTest::class.java.getResource("/testfilters/valuelist_2").file)
+            )
+        )
+
+        val filteredTests = blocklistEmptyFileFilter.filterNot(inputTests)
+
+        assertEquals(listOf(allowedTest), filteredTests)
+    }
+
+    @Test
     fun `if empty block list file all tests should be allowed`() {
         val inputTests = listOf(
             MarathonTest("pkg", "clazz", "method", emptyList()),
@@ -45,6 +64,25 @@ class SingleValueTestFilterTest {
         val filteredTests = blocklistEmptyFileFilter.filterNot(inputTests)
 
         assertEquals(inputTests, filteredTests)
+    }
+
+    @Test
+    fun `should filter allow list from value file`() {
+        val blockedTest = MarathonTest("pkg", "clazz2", "method", emptyList())
+        val allowedTest = MarathonTest("pkg", "clazz", "method", emptyList())
+        val inputTests = listOf(blockedTest, allowedTest)
+
+        val blocklistEmptyFileFilter = FullyQualifiedClassnameFilter(
+            TestFilterConfiguration.FullyQualifiedClassnameFilterConfiguration(
+                regex = null,
+                values = null,
+                file = File(SingleValueTestFilterTest::class.java.getResource("/testfilters/valuelist_2").file)
+            )
+        )
+
+        val filteredTests = blocklistEmptyFileFilter.filter(inputTests)
+
+        assertEquals(listOf(allowedTest), filteredTests)
     }
 
     @Test

--- a/core/src/test/resources/testfilters/valuelist_1
+++ b/core/src/test/resources/testfilters/valuelist_1
@@ -1,0 +1,12 @@
+#line comment
+com.example.test1
+com.example.test2 #issue link = http://test.test/issue
+
+#line comment2
+
+com.example   #flaky package
+
+  # comment3
+ClassName#test4 # comment
+SimpleTestName
+SimpleTestName2 #comment1

--- a/core/src/test/resources/testfilters/valuelist_2
+++ b/core/src/test/resources/testfilters/valuelist_2
@@ -1,0 +1,1 @@
+pkg.clazz

--- a/docs/runner/configuration/filtering.md
+++ b/docs/runner/configuration/filtering.md
@@ -212,6 +212,15 @@ com.example
 com.example.subpackage
 ```
 
+You can leave comments via the **#** symbol at the beginning of the line or after the space in a value line. 
+It can be helpful for example for the blocklist when you needed to specify the reason of skipping a test or just for commenting some values:
+
+```text
+#this is comment
+com.example #skipped because of flakiness
+com.example.subpackage
+```
+
 ### Groovy filtering
 
 With almost every filtering configuration (except for `annotationDataFilter`) it is possible to have `regex` and `values`.


### PR DESCRIPTION
Add comments support in filtering value files.
Usage via `#` symbol, like:
```
#comment
com.example #line comment
```