### PR TITLE
fix(android): detect device reboot during data clear

### DIFF
--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDevice.kt
@@ -64,7 +64,7 @@ interface AndroidDevice : Device, LogProducer, Screenshottable {
     suspend fun installPackage(absolutePath: String, reinstall: Boolean, optionalParams: List<String>): ShellCommandResult?
     suspend fun installSplitPackages(absolutePaths: List<String>, reinstall: Boolean, optionalParams: List<String>): String
     suspend fun safeUninstallPackage(appPackage: String, keepData: Boolean = false): ShellCommandResult?
-    suspend fun safeClearPackage(packageName: String): ShellCommandResult?
+    suspend fun clearPackage(packageName: String): ShellCommandResult?
     
     suspend fun safeStartScreenRecorder(remoteFilePath: String, options: VideoConfiguration)
 }

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/BaseAndroidDevice.kt
@@ -188,8 +188,8 @@ abstract class BaseAndroidDevice(
     }
 
 
-    override suspend fun safeClearPackage(packageName: String): ShellCommandResult? =
-        safeExecuteShellCommand("pm clear $packageName", "Could not clear package $packageName on device: $serialNumber")
+    override suspend fun clearPackage(packageName: String): ShellCommandResult? =
+        criticalExecuteShellCommand("pm clear $packageName", "Could not clear package $packageName on device: $serialNumber")
 
     protected suspend fun clearLogcat() = safeExecuteShellCommand("logcat -c", "Could not clear logcat on device: $serialNumber")
 

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/adam/AndroidDeviceTestRunner.kt
@@ -137,12 +137,12 @@ class AndroidDeviceTestRunner(private val device: AdamAndroidDevice, private val
         info: InstrumentationInfo
     ) {
         if (androidConfiguration.applicationPmClear) {
-            device.safeClearPackage(info.applicationPackage)?.output?.trim()?.also {
+            device.clearPackage(info.applicationPackage)?.output?.trim()?.also {
                 logger.debug { "Package ${info.applicationPackage} cleared: $it" }
             }
         }
         if (androidConfiguration.testApplicationPmClear) {
-            device.safeClearPackage(info.instrumentationPackage)?.output?.trim()?.also {
+            device.clearPackage(info.instrumentationPackage)?.output?.trim()?.also {
                 logger.debug { "Package ${info.instrumentationPackage} cleared: $it" }
             }
         }


### PR DESCRIPTION
Random device reboots should be detected and device should be reprovisioned (i.e. boot wait, install app, etc) when the data clear is unsuccessful.