### PR TITLE
feat(apple): support preferredScreenCaptureFormat

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/ios/XcresultConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/ios/XcresultConfiguration.kt
@@ -39,8 +39,8 @@ enum class PullingPolicy {
 }
 
 enum class ScreenCaptureFormat {
-    @JsonProperty("screenshots") SCREENSHOTS,
-    @JsonProperty("screenRecording") SCREEN_RECORDING;
+    @JsonProperty("SCREENSHOTS") SCREENSHOTS,
+    @JsonProperty("SCREEN_RECORDING") SCREEN_RECORDING;
 
     fun xcodevalue() = when(this) {
         SCREENSHOTS -> "screenshots"

--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/ios/XcresultConfiguration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/vendor/apple/ios/XcresultConfiguration.kt
@@ -7,6 +7,7 @@ data class XcresultConfiguration(
     @JsonProperty("pullingPolicy") val pullingPolicy: PullingPolicy = PullingPolicy.ALWAYS,
     @JsonProperty("remoteClean") val remoteClean: Boolean = true,
     @JsonProperty("attachments") val attachments: AttachmentsConfiguration = AttachmentsConfiguration(),
+    @JsonProperty("preferredScreenCaptureFormat") val preferredScreenCaptureFormat: ScreenCaptureFormat? = null,
 )
 
 data class AttachmentsConfiguration(
@@ -35,4 +36,14 @@ enum class PullingPolicy {
     @JsonProperty("NEVER") NEVER,
     @JsonProperty("ALWAYS") ALWAYS,
     @JsonProperty("ON_FAILURE") ON_FAILURE,
+}
+
+enum class ScreenCaptureFormat {
+    @JsonProperty("screenshots") SCREENSHOTS,
+    @JsonProperty("screenRecording") SCREEN_RECORDING;
+
+    fun xcodevalue() = when(this) {
+        SCREENSHOTS -> "screenshots"
+        SCREEN_RECORDING -> "screenRecording"
+    }
 }

--- a/docs/runner/apple/configure/ios.md
+++ b/docs/runner/apple/configure/ios.md
@@ -248,6 +248,21 @@ deleted on success and user attachments will always be kept in the xcresult, but
 
 Possible values for the lifetime are `KEEP_ALWAYS`, `DELETE_ON_SUCCESS` and `KEEP_NEVER`.
 
+#### xcresult screen recorder configuration
+Since Xcode 15 test execution defaults to recording test video and attaching it to xcresults. This can be configured as follows:
+```yaml
+  xcresult:
+    preferredScreenCaptureFormat: SCREENSHOTS
+```
+
+Possible values for the screen capture format are `SCREENSHOTS` and `SCREEN_RECORDING`.
+
+:::warning
+
+This setting doesn't influence marathon's screen recorder which is configured separately.
+
+:::
+
 ### Screen recorder configuration
 
 By default, marathon will record a h264-encoded video of the internal display with black mask if it is supported.

--- a/docs/runner/apple/configure/macos.md
+++ b/docs/runner/apple/configure/macos.md
@@ -186,6 +186,21 @@ deleted on success and user attachments will always be kept in the xcresult, but
 
 Possible values for the lifetime are `KEEP_ALWAYS`, `DELETE_ON_SUCCESS` and `KEEP_NEVER`.
 
+#### xcresult screen recorder configuration
+Since Xcode 15 test execution defaults to recording test video and attaching it to xcresults. This can be configured as follows:
+```yaml
+  xcresult:
+    preferredScreenCaptureFormat: SCREENSHOTS
+```
+
+Possible values for the screen capture format are `SCREENSHOTS` and `SCREEN_RECORDING`.
+
+:::warning
+
+This setting doesn't influence marathon's screen recorder which is configured separately.
+
+:::
+
 ### xctestrun Environment and TestingEnvironment variables
 
 You can specify additional Environment and TestingEnvironment variables for your test run:

--- a/sample/ios-app/Marathonfile-uiTests
+++ b/sample/ios-app/Marathonfile-uiTests
@@ -26,8 +26,11 @@ vendorConfiguration:
       username: malinskiy
       key: ${HOME}/.ssh/marathon
     knownHostsPath: ${HOME}/.ssh/known_hosts
+    # Temporary fix for https://github.com/hierynomus/sshj/pull/934
+    keepAliveInterval: "PT0H0M0S"
   xcresult:
-    pullingStrategy: ALWAYS
+    pullingPolicy: ALWAYS
     remoteClean: true
+    preferredScreenCaptureFormat: SCREENSHOTS
   lifecycle:
     onPrepare: []

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/TestRootFactory.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/TestRootFactory.kt
@@ -221,6 +221,7 @@ class TestRootFactory(
                             testBundlePath = remoteXctest,
                             testHostPath = testRunnerApp,
                             uiTargetAppPath = remoteTestApp,
+                            preferredScreenCaptureFormat = xcresultConfiguration.preferredScreenCaptureFormat?.xcodevalue(),
                         )
                     )
                 )

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/v2/TestTarget.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/v2/TestTarget.kt
@@ -38,6 +38,7 @@ class TestTarget : TestTarget {
             testRegion: String? = null,
             isUITestBundle: Boolean? = null,
             isAppHostedTestBundle: Boolean? = null,
+            preferredScreenCaptureFormat: String? = null,
         ): V2TestTarget {
             return V2TestTarget(
                 name = name,
@@ -65,6 +66,7 @@ class TestTarget : TestTarget {
                 testRegion = testRegion,
                 isUITestBundle = isUITestBundle,
                 isAppHostedTestBundle = isAppHostedTestBundle,
+                preferredScreenCaptureFormat = preferredScreenCaptureFormat,
             )
         }
 
@@ -161,6 +163,7 @@ class TestTarget : TestTarget {
         testRegion: String? = null,
         isUITestBundle: Boolean? = null,
         isAppHostedTestBundle: Boolean? = null,
+        preferredScreenCaptureFormat: String? = null,
     ) : super(
         testBundlePath,
         testHostPath,
@@ -192,6 +195,7 @@ class TestTarget : TestTarget {
         testRegion?.let { this.testRegion = it }
         isUITestBundle?.let { this.isUITestBundle = it }
         isAppHostedTestBundle?.let { this.isAppHostedTestBundle = it }
+        preferredScreenCaptureFormat?.let { this.preferredScreenCaptureFormat = it }
     }
 
     /**
@@ -270,4 +274,10 @@ class TestTarget : TestTarget {
      */
     var isUITestBundle: Boolean? by delegate.optionalDelegateFor("IsUITestBundle")
     var isAppHostedTestBundle: Boolean? by delegate.optionalDelegateFor("IsAppHostedTestBundle")
+
+    /**
+     * Added in xcode 15, possible values are [screenshots, screenRecording]. Defaults to screenRecording
+     * Ignored by previous versions of xcode
+     */
+    var preferredScreenCaptureFormat: String? by delegate.optionalDelegateFor("preferredScreenCaptureFormat")
 }


### PR DESCRIPTION
Undocumented option `preferredScreenCaptureFormat` of the v2 format of test configuration. Would be awesome to see this anywhere in the spec produced by `man xcodebuild.xctestrun` instead of release notes for xcode.