### PR TITLE
feat(ios) PreferredScreenCaptureFormat naming fixed

### DIFF
--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/v2/TestTarget.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/xctestrun/v2/TestTarget.kt
@@ -279,5 +279,5 @@ class TestTarget : TestTarget {
      * Added in xcode 15, possible values are [screenshots, screenRecording]. Defaults to screenRecording
      * Ignored by previous versions of xcode
      */
-    var preferredScreenCaptureFormat: String? by delegate.optionalDelegateFor("preferredScreenCaptureFormat")
+    var preferredScreenCaptureFormat: String? by delegate.optionalDelegateFor("PreferredScreenCaptureFormat")
 }


### PR DESCRIPTION
The issue was that in the generated `marathon.xctestrun`, the first letter of the PreferredScreenCaptureFormat was in lowercase. When you set this parameter manually from xcode in xctestrun you get 
```
<key>PreferredScreenCaptureFormat</key>
<string>screenshots</string>
```
Because of that we still got video instead of screenshots. Checked that after this edit screenshots are available in xcresult