### PR TITLE
fix(ios)/supportsTranscoding-requirement-weakened

### DIFF
--- a/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
+++ b/vendor/vendor-apple/ios/src/main/kotlin/com/malinskiy/marathon/apple/ios/AppleSimulatorDevice.kt
@@ -190,7 +190,8 @@ class AppleSimulatorDevice(
 
             deviceFeatures = detectFeatures()
 
-            supportsTranscoding = executeWorkerCommand(listOf(vendorConfiguration.screenRecordConfiguration.videoConfiguration.transcoding.binary, "-version"))?.let {
+            val transcodingVideoConfiguration = vendorConfiguration.screenRecordConfiguration.videoConfiguration.transcoding
+            supportsTranscoding = transcodingVideoConfiguration.enabled && executeWorkerCommand(listOf(transcodingVideoConfiguration.binary, "-version"))?.let {
                 if (it.successful) {
                     true
                 } else {


### PR DESCRIPTION
In our setup, the new Transcoding feature is disabled. By default, `TranscodingConfiguration.enabled == false`. However, in the `AppleSimulatorDevice`, despite this setting, we attempt to run the command `vendorConfiguration.screenRecordConfiguration.videoConfiguration.transcoding.binary --version`. On our CI environment, we do not have `ffmpeg` installed, resulting in a crash with the error message `Caused by: java.io.IOException: Cannot run program "/opt/homebrew/bin/ffmpeg": error=2, No such file or directory`.

To address this issue, I have added an additional check to verify if the feature is enabled.