### PR TITLE
fix(ios): add xcode timeout result parsing

### DIFF
--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/DeviceFailureParser.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/DeviceFailureParser.kt
@@ -4,7 +4,7 @@ import com.malinskiy.marathon.apple.logparser.TestEventProducer
 import com.malinskiy.marathon.apple.test.TestEvent
 import com.malinskiy.marathon.apple.test.TestRunFailed
 
-class DeviceFailureParser : com.malinskiy.marathon.apple.logparser.TestEventProducer {
+class DeviceFailureParser : TestEventProducer {
     private val patterns = listOf(
         "Failed to install or launch the test runner",
         "Software caused connection abort",

--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParser.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParser.kt
@@ -30,7 +30,10 @@ class TestRunProgressParser(
      */
     val FAILING_TEST_MATCHER = "(/.+:\\d+):\\serror:\\s[\\+\\-]\\[(.*)\\s(.*)\\]\\s:(\\s.*)".toRegex()
 
-    val TIMEOUT_TEST_MATCHER = """Test Case '-\[(.+) (.+)]' exceeded execution time allowance of (\d+) minutes\. The test may have hung.*""".toRegex()
+    /**
+     * Timeout case from https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance
+     */
+    val TIMEOUT_TEST_MATCHER = """Test Case '-\[(.+) (.+)]' exceeded execution time allowance of (\d+) minutes*\. The test may have hung.*""".toRegex()
     
     private var failingTestLine: String? = null
     

--- a/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
+++ b/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.malinskiy.marathon.apple.test.TestEvent
 import com.malinskiy.marathon.time.Timer
+import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.reset
@@ -103,5 +104,22 @@ class TestRunProgressParserTest {
 
         assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
             .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/patrol_1.expected").reader().readText().trimEnd())
+    }
+
+    @Test
+    fun testSample5() {
+        val parser = TestRunProgressParser(mockTimer, "")
+
+        val events = mutableListOf<TestEvent>()
+        javaClass.getResourceAsStream("/fixtures/test_output/timeout_0.log.input").bufferedReader().use {
+            it.lines().forEach { line ->
+                parser.process(line)?.let {
+                    events.addAll(it)
+                }
+            }
+        }
+
+        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
+            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/timeout_0.expected").reader().readText().trimEnd())
     }
 }

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/timeout_0.expected
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/timeout_0.expected
@@ -1,0 +1,2 @@
+TestStarted(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]))
+TestFailed(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]), startTime=1537187516000, endTime=1537187696000, trace=null)

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/timeout_0.log.input
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/timeout_0.log.input
@@ -1,0 +1,15 @@
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' started.
+    t =     0.00s Start Test at 2018-09-15 01:08:51.148
+    t =     0.03s Set Up
+    t =     0.03s     Open com.agoda.sample-app
+    t =     0.06s         Launch com.agoda.sample-app
+    t =     2.61s             Wait for com.agoda.sample-app to idle
+    t =     3.85s Waiting 30.0s for Button to exist
+    t =     4.85s     Checking `Expect predicate `exists == 1` for object Button`
+    t =     4.86s Tap Button
+    t =     4.86s     Wait for com.agoda.sample-app to idle
+    t =     4.87s     Find the Button
+    t =     4.98s         Wait for com.agoda.sample-app to idle
+    t =     4.99s     Synthesize event
+    t =     5.07s     Wait for com.agoda.sample-app to idle
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' exceeded execution time allowance of 3 minutes. The test may have hung; check Xcode's test report for additional diagnostics. If the test requires additional time, use -[XCTestCase executionTimeAllowance] or one of xcodebuild's command-line overrides.


### PR DESCRIPTION
The `TestRunProgressParser` is reading the xcrun logs to detect the end time and calculate the start time. However, when a timeout is defined from XCode and this timeout is triggered, the log looks like:
```
Test Case '-[TestTarget.TestClass test]' exceeded execution time allowance of 3 minutes. The test may have hung; check Xcode's test report for additional diagnostics. If the test requires additional time, use -[XCTestCase executionTimeAllowance] or one of xcodebuild's command-line overrides.
```
Resulting on the parser not being able to correctly identified what happened.

This PR implements an extra case in the `TestRunProgressParser` to match this case and fix the issue reported [here](https://github.com/MarathonLabs/marathon/issues/984)