### PR TITLE
[fix] NoDevicesException during local parsing

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -108,7 +108,11 @@ class Marathon(
             logSystemInformation()
             configurationValidator.validate(configuration)
 
-            deviceProvider.initialize()
+            when {
+                executionCommand is ParseCommand && testParser is LocalTestParser -> log.info("DeviceProvider is not required for local parsing")
+                else -> deviceProvider.initialize()
+            }
+
             parsedAllTests = when (testParser) {
                 is LocalTestParser -> testParser.extract()
                 is RemoteTestParser<*> -> {


### PR DESCRIPTION
At the moment, it is not possible to analyze the tests using a LocalTestParser without initialize the DeviceProvider, which is not needed for this. The following exception is thrown:

```
Caused by: com.malinskiy.marathon.exceptions.NoDevicesException: No devices found
	at com.malinskiy.marathon.android.adam.AdamDeviceProvider.initialize(AdamDeviceProvider.kt:117)
	at com.malinskiy.marathon.android.adam.AdamDeviceProvider$initialize$1.invokeSuspend(AdamDeviceProvider.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:28)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:99)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:102)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:277)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:95)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:69)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.malinskiy.marathon.Marathon.run(Marathon.kt:69)
	at com.malinskiy.marathon.cli.ApplicationViewKt.execute(ApplicationView.kt:86)
	at com.malinskiy.marathon.cli.ApplicationViewKt.access$execute(ApplicationView.kt:1)
	at com.malinskiy.marathon.cli.ApplicationViewKt$main$3.invoke(ApplicationView.kt:35)
	at com.malinskiy.marathon.cli.ApplicationViewKt$main$3.invoke(ApplicationView.kt:35)
	at com.malinskiy.marathon.cli.args.Parse.run(CliCommands.kt:84)
	at com.github.ajalt.clikt.core.CoreCliktCommandKt.parse(CoreCliktCommand.kt:107)
	at com.github.ajalt.clikt.core.CoreCliktCommandKt.main(CoreCliktCommand.kt:78)
	at com.github.ajalt.clikt.core.CoreCliktCommandKt.main(CoreCliktCommand.kt:90)
	at com.malinskiy.marathon.cli.ApplicationViewKt.main(ApplicationView.kt:36)
```

After this fix, the tests are successfully parsed:
```
I 18:25:03.065 [main @coroutine#2] <com.malinskiy.marathon.Marathon> DeviceProvider is not required for local parsing
D 18:25:03.429 [main @coroutine#2] <com.malinskiy.marathon.Marathon> Parsing took 526 ms
I 18:25:03.471 [main @coroutine#2] <c.m.m.e.c.parse.MarathonTestParseCommand> Parse execute mode. Result
I 18:25:03.475 [main] <c.m.m.exceptions.NoopExceptionsReporter> Noop exceptions reporter finished
Marathon execution finished

```