### PR TITLE
(iOS) Fix empty failure tag on JUnit XML report when unknown class

### DIFF
--- a/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParser.kt
+++ b/vendor/vendor-apple/base/src/main/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParser.kt
@@ -33,7 +33,7 @@ class TestRunProgressParser(
      * $3 = test_case
      * $4 = reason
      */
-    val FAILING_TEST_MATCHER = "(/.+:\\d+):\\serror:\\s[\\+\\-]\\[(.*)\\s(.*)\\]\\s:(\\s.*)".toRegex()
+    val FAILING_TEST_MATCHER = "(/.+|<unknown>:\\d+):\\serror:\\s[\\+\\-]\\[(.*)\\s(.*)\\]\\s:(\\s.*)".toRegex()
 
     /**
      * Timeout case from https://developer.apple.com/documentation/xctest/xctestcase/3526064-executiontimeallowance

--- a/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
+++ b/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
@@ -5,12 +5,21 @@ import assertk.assertions.isEqualTo
 import com.malinskiy.marathon.apple.test.TestEvent
 import com.malinskiy.marathon.time.Timer
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.mockito.Mockito.reset
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.stream.Stream
 
+@RunWith(Parameterized::class)
 class TestRunProgressParserTest {
+
     private val mockTimer = mock<Timer>()
     private val mockedTimeMillis = 1537187696000L
 
@@ -20,29 +29,31 @@ class TestRunProgressParserTest {
         whenever(mockTimer.currentTimeMillis()).thenReturn(mockedTimeMillis)
     }
 
-    @Test
-    fun testSample1() {
-        val parser = TestRunProgressParser(mockTimer, "")
+    data class TestData(val caseName: String, val targetName: String)
 
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/success_0.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
+    class TestDataProvider : ArgumentsProvider {
+        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments?>? {
+            return Stream.of(
+                Arguments.of(TestData(caseName = "success_0", targetName = "")),
+                Arguments.of(TestData(caseName = "patrol_0", targetName = "testTarget")),
+                Arguments.of(TestData(caseName = "success_multiple_0", targetName = "")),
+                Arguments.of(TestData(caseName = "success_multiple_0", targetName = "testTarget")),
+                Arguments.of(TestData(caseName = "patrol_1", targetName = "testTarget")),
+                Arguments.of(TestData(caseName = "timeout_0", targetName = "")),
+                Arguments.of(TestData(caseName = "timeout_1", targetName = "")),
+                Arguments.of(TestData(caseName = "failure_0", targetName = "")),
+                Arguments.of(TestData(caseName = "failure_1", targetName = "")),
+            )
         }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/success_0.expected").reader().readText().trimEnd())
     }
 
-    @Test
-    fun testSample2() {
-        val parser = TestRunProgressParser(mockTimer, "testTarget")
+    @ParameterizedTest(name = "{0}")
+    @ArgumentsSource(TestDataProvider::class)
+    fun test(testData: TestData) {
+        val parser = TestRunProgressParser(mockTimer, testData.targetName)
 
         val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/patrol_0.log.input").bufferedReader().use {
+        javaClass.getResourceAsStream("/fixtures/test_output/${testData.caseName}.log.input").bufferedReader().use {
             it.lines().forEach { line ->
                 parser.process(line)?.let {
                     events.addAll(it)
@@ -51,125 +62,6 @@ class TestRunProgressParserTest {
         }
 
         assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/patrol_0.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample3() {
-        val parser = TestRunProgressParser(mockTimer, "")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/success_multiple_0.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/success_multiple_0.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample3WithTargetOverride() {
-        val parser = TestRunProgressParser(mockTimer, "testTarget")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/success_multiple_0.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/success_multiple_0.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample4() {
-        val parser = TestRunProgressParser(mockTimer, "testTarget")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/patrol_1.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/patrol_1.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample5() {
-        val parser = TestRunProgressParser(mockTimer, "")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/timeout_0.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/timeout_0.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample6() {
-        val parser = TestRunProgressParser(mockTimer, "")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/timeout_1.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/timeout_1.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample7() {
-        val parser = TestRunProgressParser(mockTimer, "")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/failure_0.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/failure_0.expected").reader().readText().trimEnd())
-    }
-
-    @Test
-    fun testSample8() {
-        val parser = TestRunProgressParser(mockTimer, "")
-
-        val events = mutableListOf<TestEvent>()
-        javaClass.getResourceAsStream("/fixtures/test_output/failure_1.log.input").bufferedReader().use {
-            it.lines().forEach { line ->
-                parser.process(line)?.let {
-                    events.addAll(it)
-                }
-            }
-        }
-
-        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
-            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/failure_1.expected").reader().readText().trimEnd())
+            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/${testData.caseName}.expected").reader().readText().trimEnd())
     }
 }

--- a/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
+++ b/vendor/vendor-apple/base/src/test/kotlin/com/malinskiy/marathon/apple/logparser/parser/TestRunProgressParserTest.kt
@@ -4,7 +4,6 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.malinskiy.marathon.apple.test.TestEvent
 import com.malinskiy.marathon.time.Timer
-import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.reset
@@ -138,5 +137,39 @@ class TestRunProgressParserTest {
 
         assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
             .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/timeout_1.expected").reader().readText().trimEnd())
+    }
+
+    @Test
+    fun testSample7() {
+        val parser = TestRunProgressParser(mockTimer, "")
+
+        val events = mutableListOf<TestEvent>()
+        javaClass.getResourceAsStream("/fixtures/test_output/failure_0.log.input").bufferedReader().use {
+            it.lines().forEach { line ->
+                parser.process(line)?.let {
+                    events.addAll(it)
+                }
+            }
+        }
+
+        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
+            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/failure_0.expected").reader().readText().trimEnd())
+    }
+
+    @Test
+    fun testSample8() {
+        val parser = TestRunProgressParser(mockTimer, "")
+
+        val events = mutableListOf<TestEvent>()
+        javaClass.getResourceAsStream("/fixtures/test_output/failure_1.log.input").bufferedReader().use {
+            it.lines().forEach { line ->
+                parser.process(line)?.let {
+                    events.addAll(it)
+                }
+            }
+        }
+
+        assertThat(events.map { it.toString() }.reduce { acc, s -> acc + "\n" + s })
+            .isEqualTo(javaClass.getResourceAsStream("/fixtures/test_output/failure_1.expected").reader().readText().trimEnd())
     }
 }

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_0.expected
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_0.expected
@@ -1,0 +1,2 @@
+TestStarted(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]))
+TestFailed(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]), startTime=1537187691756, endTime=1537187696000, trace=/Users/vagrant/git/apps/sample_appUITests/Target/TestCases/MoreTests.swift:33:XCTAssertTrue failed - This test failed.)

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_0.log.input
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_0.log.input
@@ -1,0 +1,12 @@
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' started.
+    t =     0.00s Start Test at 2018-09-15 01:08:51.148
+    t =     0.03s Set Up
+    t =     0.03s     Open com.agoda.sample-app
+    t =     0.06s         Launch com.agoda.sample-app
+    t =     2.61s             Wait for com.agoda.sample-app to idle
+    t =     3.85s Waiting 30.0s for Button to exist
+/Users/vagrant/git/apps/sample_appUITests/Target/TestCases/MoreTests.swift:33: error: -[sample_appUITests.MoreTests testPresentModal] : XCTAssertTrue failed - This test failed.
+    t =     4.20s Tear Down
+
+Test sample_appUITests.MoreTests.testPresentModal finished with result <failed> after 4.244 seconds
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' failed (4.244 seconds).

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_1.expected
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_1.expected
@@ -1,0 +1,2 @@
+TestStarted(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]))
+TestFailed(id=Test(pkg=sample_appUITests, clazz=MoreTests, method=testPresentModal, metaProperties=[]), startTime=1537187691756, endTime=1537187696000, trace=<unknown>:0:XCTAssertTrue failed - This test also failed with more details {()

--- a/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_1.log.input
+++ b/vendor/vendor-apple/base/src/test/resources/fixtures/test_output/failure_1.log.input
@@ -1,0 +1,13 @@
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' started.
+    t =     0.00s Start Test at 2018-09-15 01:08:51.148
+    t =     0.03s Set Up
+    t =     0.03s     Open com.agoda.sample-app
+    t =     0.06s         Launch com.agoda.sample-app
+    t =     2.61s             Wait for com.agoda.sample-app to idle
+<unknown>:0: error: -[sample_appUITests.MoreTests testPresentModal] : XCTAssertTrue failed - This test also failed with more details {(
+    Button, identifier: 'Button 1', label: 'Save', Selected,
+    Button, identifier: 'Button 2', label: 'Cancel'
+)}
+    t =     4.20s Tear Down
+Test sample_appUITests.MoreTests.testPresentModal finished with result <failed> after 4.244 seconds
+Test Case '-[sample_appUITests.MoreTests testPresentModal]' failed (4.244 seconds).


### PR DESCRIPTION
Proposal to fix the issue reported [here](https://github.com/MarathonLabs/marathon/issues/999).

When the xcode execution log prints a test failure with an unknown class, the parser does not detect the error trace with the current regex expression, expecting a proper class path (`/path/to/class`):
```log
...
<DebugLogPrinter> <unknown>:0: error: -[TestTarget.Tests testAccessibility] : Element has no description
<DebugLogPrinter>     t =     4.79s Find the Any (Descendant with identity binding to AX element pid: 62723, elementOrHash.elementID: 105553170498336.190)
<DebugLogPrinter>     t =     4.80s Checking existence of `"empty state view" StaticText`
<DebugLogPrinter>     t =     4.81s Find the "empty state view" StaticText
...
```

which results into the following failure tag:
```xml
    ...
    <testcase name="testAccessibility" time="13.387" classname="TestTarget.Tests">
      <failure></failure>
    </testcase>
    ...
```

For now I do not understand why the log says "unknown" class. However, this change would provide some information on the JUnit XML report about the stacktrace, as a first step to tackle the issue.

Note 1: When multiline stacktrace the parser only captures the first line.
Note 2: as an additional change the related test could be parameterized to simplify the addition of new tests / maintenance of the test.