### PR TITLE
Introduce allowEmptyTestSuites parameter

### DIFF
--- a/configuration/src/main/kotlin/com/malinskiy/marathon/config/Configuration.kt
+++ b/configuration/src/main/kotlin/com/malinskiy/marathon/config/Configuration.kt
@@ -51,6 +51,8 @@ data class Configuration private constructor(
     val bugsnagReporting: Boolean,
     val deviceInitializationTimeoutMillis: Long,
     val ciConfiguration: CIConfiguration,
+
+    val allowEmptyTestSuites: Boolean,
 ) {
     fun toMap() =
         mapOf<String, String>(
@@ -77,6 +79,7 @@ data class Configuration private constructor(
             "vendorConfiguration" to vendorConfiguration.toString(),
             "deviceInitializationTimeoutMillis" to deviceInitializationTimeoutMillis.toString(),
             "ciConfiguration" to ciConfiguration.toString(),
+            "allowEmptyTestSuites" to allowEmptyTestSuites.toString(),
         )
 
     override fun equals(other: Any?): Boolean {
@@ -111,6 +114,7 @@ data class Configuration private constructor(
         if (bugsnagReporting != other.bugsnagReporting) return false
         if (deviceInitializationTimeoutMillis != other.deviceInitializationTimeoutMillis) return false
         if (ciConfiguration != other.ciConfiguration) return false
+        if (allowEmptyTestSuites != other.allowEmptyTestSuites) return false
 
         return true
     }
@@ -142,42 +146,45 @@ data class Configuration private constructor(
         result = 31 * result + bugsnagReporting.hashCode()
         result = 31 * result + deviceInitializationTimeoutMillis.hashCode()
         result = 31 * result + ciConfiguration.hashCode()
+        result = 31 * result + allowEmptyTestSuites.hashCode()
         return result
     }
 
-     data class Builder(
-         val name: String,
-         val outputDir: File,
-         var analyticsConfiguration: AnalyticsConfiguration = AnalyticsConfiguration.DisabledAnalytics,
-         var poolingStrategy: PoolingStrategyConfiguration = PoolingStrategyConfiguration.OmniPoolingStrategyConfiguration,
-         var shardingStrategy: ShardingStrategyConfiguration = ShardingStrategyConfiguration.ParallelShardingStrategyConfiguration,
-         var sortingStrategy: SortingStrategyConfiguration = SortingStrategyConfiguration.NoSortingStrategyConfiguration,
-         var batchingStrategy: BatchingStrategyConfiguration = BatchingStrategyConfiguration.IsolateBatchingStrategyConfiguration,
-         var flakinessStrategy: FlakinessStrategyConfiguration = FlakinessStrategyConfiguration.IgnoreFlakinessStrategyConfiguration,
-         var retryStrategy: RetryStrategyConfiguration = RetryStrategyConfiguration.NoRetryStrategyConfiguration,
-         var filteringConfiguration: FilteringConfiguration = FilteringConfiguration(emptyList(), emptyList()),
+    data class Builder(
+        val name: String,
+        val outputDir: File,
+        var analyticsConfiguration: AnalyticsConfiguration = AnalyticsConfiguration.DisabledAnalytics,
+        var poolingStrategy: PoolingStrategyConfiguration = PoolingStrategyConfiguration.OmniPoolingStrategyConfiguration,
+        var shardingStrategy: ShardingStrategyConfiguration = ShardingStrategyConfiguration.ParallelShardingStrategyConfiguration,
+        var sortingStrategy: SortingStrategyConfiguration = SortingStrategyConfiguration.NoSortingStrategyConfiguration,
+        var batchingStrategy: BatchingStrategyConfiguration = BatchingStrategyConfiguration.IsolateBatchingStrategyConfiguration,
+        var flakinessStrategy: FlakinessStrategyConfiguration = FlakinessStrategyConfiguration.IgnoreFlakinessStrategyConfiguration,
+        var retryStrategy: RetryStrategyConfiguration = RetryStrategyConfiguration.NoRetryStrategyConfiguration,
+        var filteringConfiguration: FilteringConfiguration = FilteringConfiguration(emptyList(), emptyList()),
 
-         var ignoreFailures: Boolean = false,
-         var isCodeCoverageEnabled: Boolean = false,
-         var executionStrategy: ExecutionStrategyConfiguration = ExecutionStrategyConfiguration(),
-         var uncompletedTestRetryQuota: Int = Integer.MAX_VALUE,
+        var ignoreFailures: Boolean = false,
+        var isCodeCoverageEnabled: Boolean = false,
+        var executionStrategy: ExecutionStrategyConfiguration = ExecutionStrategyConfiguration(),
+        var uncompletedTestRetryQuota: Int = Integer.MAX_VALUE,
 
-         var includeSerialRegexes: Collection<Regex> = emptyList(),
-         var excludeSerialRegexes: Collection<Regex> = emptyList(),
+        var includeSerialRegexes: Collection<Regex> = emptyList(),
+        var excludeSerialRegexes: Collection<Regex> = emptyList(),
 
-         var testBatchTimeoutMillis: Long = DEFAULT_BATCH_EXECUTION_TIMEOUT_MILLIS,
-         var testOutputTimeoutMillis: Long = DEFAULT_OUTPUT_TIMEOUT_MILLIS,
-         var debug: Boolean = true,
+        var testBatchTimeoutMillis: Long = DEFAULT_BATCH_EXECUTION_TIMEOUT_MILLIS,
+        var testOutputTimeoutMillis: Long = DEFAULT_OUTPUT_TIMEOUT_MILLIS,
+        var debug: Boolean = true,
 
-         var screenRecordingPolicy: ScreenRecordingPolicy = ScreenRecordingPolicy.ON_FAILURE,
+        var screenRecordingPolicy: ScreenRecordingPolicy = ScreenRecordingPolicy.ON_FAILURE,
 
-         var analyticsTracking: Boolean = true,
-         var bugsnagReporting: Boolean = true,
-         var deviceInitializationTimeoutMillis: Long = DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS,
+        var analyticsTracking: Boolean = true,
+        var bugsnagReporting: Boolean = true,
+        var deviceInitializationTimeoutMillis: Long = DEFAULT_DEVICE_INITIALIZATION_TIMEOUT_MILLIS,
 
-         var outputConfiguration: OutputConfiguration = OutputConfiguration(),
-         var vendorConfiguration: VendorConfiguration = VendorConfiguration.EmptyVendorConfiguration(),
-         var ciConfiguration: CIConfiguration = CIConfiguration.None,
+        var outputConfiguration: OutputConfiguration = OutputConfiguration(),
+        var vendorConfiguration: VendorConfiguration = VendorConfiguration.EmptyVendorConfiguration(),
+        var ciConfiguration: CIConfiguration = CIConfiguration.None,
+
+        var allowEmptyTestSuites: Boolean = false,
     ) {
         fun build(): Configuration {
             return Configuration(
@@ -207,6 +214,7 @@ data class Configuration private constructor(
                 bugsnagReporting = bugsnagReporting,
                 deviceInitializationTimeoutMillis = deviceInitializationTimeoutMillis,
                 ciConfiguration = ciConfiguration,
+                allowEmptyTestSuites = allowEmptyTestSuites,
             )
         }
     }

--- a/configuration/src/test/kotlin/com/malinskiy/marathon/config/vendor/AndroidConfigurationTest.kt
+++ b/configuration/src/test/kotlin/com/malinskiy/marathon/config/vendor/AndroidConfigurationTest.kt
@@ -226,4 +226,32 @@ class AndroidConfigurationTest {
         val androidConfiguration = configurationFactory.parse(marathonfile).vendorConfiguration as VendorConfiguration.AndroidConfiguration
         androidConfiguration.extraApplicationsOutput shouldBeEqualTo null
     }
+
+    @Test
+    fun `if android sdk is not null allowEmptyTestSuites should be false by default`() {
+        val marathonfile = File(AndroidConfigurationTest::class.java.getResource("/fixture/config/android/sample_1.yaml").file)
+        val environmentReader = mock<EnvironmentReader>()
+        whenever(environmentReader.read()).thenReturn(EnvironmentConfiguration(env))
+
+        val configurationFactory = ConfigurationFactory(
+            marathonfileDir = mockMarathonFileDir,
+            environmentReader = environmentReader,
+        )
+
+        configurationFactory.parse(marathonfile).allowEmptyTestSuites shouldBeEqualTo false
+    }
+
+    @Test
+    fun `if android sdk is not null allowEmptyTestSuites should be equal if provided`() {
+        val marathonfile = File(AndroidConfigurationTest::class.java.getResource("/fixture/config/android/sample_7.yaml").file)
+        val environmentReader = mock<EnvironmentReader>()
+        whenever(environmentReader.read()).thenReturn(EnvironmentConfiguration(env))
+
+        val configurationFactory = ConfigurationFactory(
+            marathonfileDir = mockMarathonFileDir,
+            environmentReader = environmentReader,
+        )
+
+        configurationFactory.parse(marathonfile).allowEmptyTestSuites shouldBeEqualTo true
+    }
 }

--- a/configuration/src/test/resources/fixture/config/android/sample_7.yaml
+++ b/configuration/src/test/resources/fixture/config/android/sample_7.yaml
@@ -1,0 +1,8 @@
+name: "sample-app tests"
+outputDir: "./marathon"
+vendorConfiguration:
+  type: "Android"
+  testApplicationApk: "foo/bar"
+  serialStrategy: "AUTOMATIC"
+  waitForDevicesTimeoutMillis: 15000
+allowEmptyTestSuites: true

--- a/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/Marathon.kt
@@ -140,7 +140,7 @@ class Marathon(
             }
         )
 
-        if (parsedAllTests.isEmpty()) throw NoTestCasesFoundException("No tests cases were found")
+        if (parsedAllTests.isEmpty() && !configuration.allowEmptyTestSuites) throw NoTestCasesFoundException("No tests cases were found")
         val parsedFilteredTests = applyTestFilters(parsedAllTests)
 
         if (executionCommand is ParseCommand) {


### PR DESCRIPTION
Introduce allowEmptyTestSuites parameter to not fail if no tests were discovered to run.
This is very useful when trying to run tests on a whole multi-module android project using marathon-gradle-plugin